### PR TITLE
Remove typed dicts in favor of Pydantic

### DIFF
--- a/examples/affinity-workers/event.py
+++ b/examples/affinity-workers/event.py
@@ -1,5 +1,6 @@
 from dotenv import load_dotenv
 
+from hatchet_sdk.clients.events import PushEventOptions
 from hatchet_sdk.hatchet import Hatchet
 
 load_dotenv()
@@ -9,5 +10,5 @@ hatchet = Hatchet(debug=True)
 hatchet.event.push(
     "affinity:run",
     {"test": "test"},
-    options={"additional_metadata": {"hello": "moon"}},
+    options=PushEventOptions(additional_metadata={"hello": "moon"}),
 )

--- a/examples/affinity-workers/worker.py
+++ b/examples/affinity-workers/worker.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv
 
 from hatchet_sdk import Context, Hatchet, WorkerLabelComparator
+from hatchet_sdk.labels import DesiredWorkerLabel
 
 load_dotenv()
 
@@ -11,12 +12,12 @@ hatchet = Hatchet(debug=True)
 class AffinityWorkflow:
     @hatchet.step(
         desired_worker_labels={
-            "model": {"value": "fancy-ai-model-v2", "weight": 10},
-            "memory": {
-                "value": 256,
-                "required": True,
-                "comparator": WorkerLabelComparator.LESS_THAN,
-            },
+            "model": DesiredWorkerLabel(value="fancy-ai-model-v2", weight=10),
+            "memory": DesiredWorkerLabel(
+                value=256,
+                required=True,
+                comparator=WorkerLabelComparator.LESS_THAN,
+            ),
         },
     )
     async def step(self, context: Context) -> dict[str, str | None]:

--- a/examples/bulk_fanout/stream.py
+++ b/examples/bulk_fanout/stream.py
@@ -31,7 +31,7 @@ async def main() -> None:
     workflowRun = hatchet.admin.run_workflow(
         "Parent",
         {"n": 2},
-        options={"additional_metadata": {streamKey: streamVal}},
+        options=TriggerWorkflowOptions(additional_metadata={streamKey: streamVal}),
     )
 
     # Stream all events for the additional meta key value

--- a/examples/bulk_fanout/worker.py
+++ b/examples/bulk_fanout/worker.py
@@ -4,7 +4,7 @@ from typing import Any
 from dotenv import load_dotenv
 
 from hatchet_sdk import Context, Hatchet
-from hatchet_sdk.clients.admin import ChildWorkflowRunDict
+from hatchet_sdk.clients.admin import ChildTriggerWorkflowOptions, ChildWorkflowRunDict
 
 load_dotenv()
 
@@ -22,18 +22,17 @@ class BulkParent:
 
         n = context.workflow_input().get("n", 100)
 
-        child_workflow_runs: list[ChildWorkflowRunDict] = []
-
-        for i in range(n):
-
-            child_workflow_runs.append(
-                {
-                    "workflow_name": "BulkChild",
-                    "input": {"a": str(i)},
-                    "key": f"child{i}",
-                    "options": {"additional_metadata": {"hello": "earth"}},
-                }
+        child_workflow_runs = [
+            ChildWorkflowRunDict(
+                workflow_name="BulkChild",
+                input={"a": str(i)},
+                key=f"child{i}",
+                options=ChildTriggerWorkflowOptions(
+                    additional_metadata={"hello": "earth"}
+                ),
             )
+            for i in range(n)
+        ]
 
         if len(child_workflow_runs) == 0:
             return {}

--- a/examples/dedupe/worker.py
+++ b/examples/dedupe/worker.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from dotenv import load_dotenv
 
-from hatchet_sdk import Context, Hatchet
+from hatchet_sdk import ChildTriggerWorkflowOptions, Context, Hatchet
 from hatchet_sdk.clients.admin import DedupeViolationErr
 from hatchet_sdk.loader import ClientConfig
 
@@ -29,7 +29,9 @@ class DedupeParent:
                             "DedupeChild",
                             {"a": str(i)},
                             key=f"child{i}",
-                            options={"additional_metadata": {"dedupe": "test"}},
+                            options=ChildTriggerWorkflowOptions(
+                                additional_metadata={"dedupe": "test"}
+                            ),
                         )
                     ).result()
                 )

--- a/examples/events/test_event.py
+++ b/examples/events/test_event.py
@@ -24,34 +24,34 @@ async def test_async_event_push(aiohatchet: Hatchet) -> None:
 @pytest.mark.asyncio(scope="session")
 async def test_async_event_bulk_push(aiohatchet: Hatchet) -> None:
 
-    events: List[BulkPushEventWithMetadata] = [
-        {
-            "key": "event1",
-            "payload": {"message": "This is event 1"},
-            "additional_metadata": {"source": "test", "user_id": "user123"},
-        },
-        {
-            "key": "event2",
-            "payload": {"message": "This is event 2"},
-            "additional_metadata": {"source": "test", "user_id": "user456"},
-        },
-        {
-            "key": "event3",
-            "payload": {"message": "This is event 3"},
-            "additional_metadata": {"source": "test", "user_id": "user789"},
-        },
+    events = [
+        BulkPushEventWithMetadata(
+            key="event1",
+            payload={"message": "This is event 1"},
+            additional_metadata={"source": "test", "user_id": "user123"},
+        ),
+        BulkPushEventWithMetadata(
+            key="event2",
+            payload={"message": "This is event 2"},
+            additional_metadata={"source": "test", "user_id": "user456"},
+        ),
+        BulkPushEventWithMetadata(
+            key="event3",
+            payload={"message": "This is event 3"},
+            additional_metadata={"source": "test", "user_id": "user789"},
+        ),
     ]
-    opts: BulkPushEventOptions = {"namespace": "bulk-test"}
+    opts = BulkPushEventOptions(namespace="bulk-test")
 
     e = await aiohatchet.event.async_bulk_push(events, opts)
 
     assert len(e) == 3
 
     # Sort both lists of events by their key to ensure comparison order
-    sorted_events = sorted(events, key=lambda x: x["key"])
+    sorted_events = sorted(events, key=lambda x: x.key)
     sorted_returned_events = sorted(e, key=lambda x: x.key)
     namespace = "bulk-test"
 
     # Check that the returned events match the original events
     for original_event, returned_event in zip(sorted_events, sorted_returned_events):
-        assert returned_event.key == namespace + original_event["key"]
+        assert returned_event.key == namespace + original_event.key

--- a/examples/fanout/stream.py
+++ b/examples/fanout/stream.py
@@ -31,7 +31,7 @@ async def main() -> None:
     workflowRun = hatchet.admin.run_workflow(
         "Parent",
         {"n": 2},
-        options={"additional_metadata": {streamKey: streamVal}},
+        options=TriggerWorkflowOptions(additional_metadata={streamKey: streamVal}),
     )
 
     # Stream all events for the additional meta key value

--- a/examples/fanout/sync_stream.py
+++ b/examples/fanout/sync_stream.py
@@ -31,7 +31,7 @@ def main() -> None:
     workflowRun = hatchet.admin.run_workflow(
         "Parent",
         {"n": 2},
-        options={"additional_metadata": {streamKey: streamVal}},
+        options=TriggerWorkflowOptions(additional_metadata={streamKey: streamVal}),
     )
 
     # Stream all events for the additional meta key value

--- a/examples/fanout/worker.py
+++ b/examples/fanout/worker.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from dotenv import load_dotenv
 
-from hatchet_sdk import Context, Hatchet
+from hatchet_sdk import ChildTriggerWorkflowOptions, Context, Hatchet
 
 load_dotenv()
 
@@ -28,7 +28,9 @@ class Parent:
                         "Child",
                         {"a": str(i)},
                         key=f"child{i}",
-                        options={"additional_metadata": {"hello": "earth"}},
+                        options=ChildTriggerWorkflowOptions(
+                            additional_metadata={"hello": "earth"}
+                        ),
                     )
                 ).result()
             )

--- a/examples/simple/event.py
+++ b/examples/simple/event.py
@@ -3,7 +3,7 @@ from typing import List
 from dotenv import load_dotenv
 
 from hatchet_sdk import new_client
-from hatchet_sdk.clients.events import BulkPushEventWithMetadata
+from hatchet_sdk.clients.events import BulkPushEventOptions, BulkPushEventWithMetadata
 
 load_dotenv()
 
@@ -34,8 +34,7 @@ events = [
 
 
 result = client.event.bulk_push(
-    events,
-    options={"namespace": "bulk-test"},
+    events, options=BulkPushEventOptions(namespace="bulk-test")
 )
 
 print(result)

--- a/examples/simple/event.py
+++ b/examples/simple/event.py
@@ -14,22 +14,22 @@ client.event.push(
     "user:create", {"test": "test"}, options={"additional_metadata": {"hello": "moon"}}
 )
 
-events: List[BulkPushEventWithMetadata] = [
-    {
-        "key": "event1",
-        "payload": {"message": "This is event 1"},
-        "additional_metadata": {"source": "test", "user_id": "user123"},
-    },
-    {
-        "key": "event2",
-        "payload": {"message": "This is event 2"},
-        "additional_metadata": {"source": "test", "user_id": "user456"},
-    },
-    {
-        "key": "event3",
-        "payload": {"message": "This is event 3"},
-        "additional_metadata": {"source": "test", "user_id": "user789"},
-    },
+events = [
+    BulkPushEventWithMetadata(
+        key="event1",
+        payload={"message": "This is event 1"},
+        additional_metadata={"source": "test", "user_id": "user123"},
+    ),
+    BulkPushEventWithMetadata(
+        key="event2",
+        payload={"message": "This is event 2"},
+        additional_metadata={"source": "test", "user_id": "user456"},
+    ),
+    BulkPushEventWithMetadata(
+        key="event3",
+        payload={"message": "This is event 3"},
+        additional_metadata={"source": "test", "user_id": "user789"},
+    ),
 ]
 
 

--- a/examples/simple/event.py
+++ b/examples/simple/event.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from dotenv import load_dotenv
 
 from hatchet_sdk import new_client
-from hatchet_sdk.clients.events import BulkPushEventOptions, BulkPushEventWithMetadata
+from hatchet_sdk.clients.events import BulkPushEventOptions, BulkPushEventWithMetadata, PushEventOptions
 
 load_dotenv()
 
@@ -11,7 +9,7 @@ client = new_client()
 
 # client.event.push("user:create", {"test": "test"})
 client.event.push(
-    "user:create", {"test": "test"}, options={"additional_metadata": {"hello": "moon"}}
+    "user:create", {"test": "test"}, options=PushEventOptions(additional_metadata={"hello": "moon"})
 )
 
 events = [

--- a/examples/simple/event.py
+++ b/examples/simple/event.py
@@ -1,7 +1,11 @@
 from dotenv import load_dotenv
 
 from hatchet_sdk import new_client
-from hatchet_sdk.clients.events import BulkPushEventOptions, BulkPushEventWithMetadata, PushEventOptions
+from hatchet_sdk.clients.events import (
+    BulkPushEventOptions,
+    BulkPushEventWithMetadata,
+    PushEventOptions,
+)
 
 load_dotenv()
 
@@ -9,7 +13,9 @@ client = new_client()
 
 # client.event.push("user:create", {"test": "test"})
 client.event.push(
-    "user:create", {"test": "test"}, options=PushEventOptions(additional_metadata={"hello": "moon"})
+    "user:create",
+    {"test": "test"},
+    options=PushEventOptions(additional_metadata={"hello": "moon"}),
 )
 
 events = [

--- a/examples/sticky_workers/event.py
+++ b/examples/sticky_workers/event.py
@@ -1,5 +1,6 @@
 from dotenv import load_dotenv
 
+from hatchet_sdk.clients.events import PushEventOptions
 from hatchet_sdk.hatchet import Hatchet
 
 load_dotenv()
@@ -10,5 +11,5 @@ hatchet = Hatchet(debug=True)
 hatchet.event.push(
     "sticky:parent",
     {"test": "test"},
-    options={"additional_metadata": {"hello": "moon"}},
+    options=PushEventOptions(additional_metadata={"hello": "moon"}),
 )

--- a/examples/sticky_workers/worker.py
+++ b/examples/sticky_workers/worker.py
@@ -1,6 +1,6 @@
 from dotenv import load_dotenv
 
-from hatchet_sdk import Context, Hatchet, StickyStrategy
+from hatchet_sdk import ChildTriggerWorkflowOptions, Context, Hatchet, StickyStrategy
 from hatchet_sdk.context.context import ContextAioImpl
 
 load_dotenv()
@@ -21,7 +21,7 @@ class StickyWorkflow:
     @hatchet.step(parents=["step1a", "step1b"])
     async def step2(self, context: ContextAioImpl) -> dict[str, str | None]:
         ref = await context.spawn_workflow(
-            "StickyChildWorkflow", {}, options={"sticky": True}
+            "StickyChildWorkflow", {}, options=ChildTriggerWorkflowOptions(sticky=True)
         )
 
         await ref.result()

--- a/examples/sync_to_async/worker.py
+++ b/examples/sync_to_async/worker.py
@@ -6,6 +6,7 @@ from typing import Any
 from dotenv import load_dotenv
 
 from hatchet_sdk import Context, sync_to_async
+from hatchet_sdk.clients.admin import ChildTriggerWorkflowOptions
 from hatchet_sdk.v2.hatchet import Hatchet
 
 os.environ["PYTHONASYNCIODEBUG"] = "1"
@@ -31,7 +32,9 @@ async def fanout_sync_async(context: Context) -> dict[str, Any]:
                     "Child",
                     {"a": str(i)},
                     key=f"child{i}",
-                    options={"additional_metadata": {"hello": "earth"}},
+                    options=ChildTriggerWorkflowOptions(
+                        additional_metadata={"hello": "earth"}
+                    ),
                 )
             ).result()
         )

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, TypeVar, Union
 
 import grpc
 from google.protobuf import timestamp_pb2
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from hatchet_sdk.clients.rest.models.workflow_run import WorkflowRun
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
@@ -52,7 +52,7 @@ class ScheduleTriggerWorkflowOptions(BaseModel):
 
 
 class ChildTriggerWorkflowOptions(BaseModel):
-    additional_metadata: AdditionalMetadata = {}
+    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
     sticky: bool | None = None
 
 
@@ -64,7 +64,7 @@ class ChildWorkflowRunDict(BaseModel):
 
 
 class TriggerWorkflowOptions(ScheduleTriggerWorkflowOptions):
-    additional_metadata: AdditionalMetadata = {}
+    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
     desired_worker_id: str | None = None
     namespace: str | None = None
 

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -31,7 +31,7 @@ from hatchet_sdk.utils.tracing import (
     inject_carrier_into_metadata,
     parse_carrier_from_metadata,
 )
-from hatchet_sdk.utils.types import AdditionalMetadata, Input
+from hatchet_sdk.utils.types import JSONSerializableDict
 from hatchet_sdk.workflow_run import RunRef, WorkflowRunRef
 
 from ..loader import ClientConfig
@@ -52,26 +52,26 @@ class ScheduleTriggerWorkflowOptions(BaseModel):
 
 
 class ChildTriggerWorkflowOptions(BaseModel):
-    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
+    additional_metadata: JSONSerializableDict = Field(default_factory=dict)
     sticky: bool | None = None
 
 
 class ChildWorkflowRunDict(BaseModel):
     workflow_name: str
-    input: Input
+    input: JSONSerializableDict
     options: ChildTriggerWorkflowOptions
     key: str | None = None
 
 
 class TriggerWorkflowOptions(ScheduleTriggerWorkflowOptions):
-    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
+    additional_metadata: JSONSerializableDict = Field(default_factory=dict)
     desired_worker_id: str | None = None
     namespace: str | None = None
 
 
 class WorkflowRunDict(BaseModel):
     workflow_name: str
-    input: Input
+    input: JSONSerializableDict
     options: TriggerWorkflowOptions
 
 
@@ -133,7 +133,7 @@ class AdminClientBase:
         self,
         name: str,
         schedules: list[Union[datetime, timestamp_pb2.Timestamp]],
-        input: Input = {},
+        input: JSONSerializableDict = {},
         options: ScheduleTriggerWorkflowOptions = ScheduleTriggerWorkflowOptions(),
     ) -> ScheduleWorkflowRequest:
         timestamp_schedules = []
@@ -175,7 +175,7 @@ class AdminClientAioImpl(AdminClientBase):
     async def run(
         self,
         function: Union[str, Callable[[Any], T]],
-        input: Input,
+        input: JSONSerializableDict,
         options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
     ) -> "RunRef[T]":
         workflow_name = cast(
@@ -197,7 +197,7 @@ class AdminClientAioImpl(AdminClientBase):
     async def run_workflow(
         self,
         workflow_name: str,
-        input: Input,
+        input: JSONSerializableDict,
         options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
     ) -> WorkflowRunRef:
         ctx = parse_carrier_from_metadata(options.additional_metadata)
@@ -335,7 +335,7 @@ class AdminClientAioImpl(AdminClientBase):
         self,
         name: str,
         schedules: list[Union[datetime, timestamp_pb2.Timestamp]],
-        input: Input = {},
+        input: JSONSerializableDict = {},
         options: ScheduleTriggerWorkflowOptions = ScheduleTriggerWorkflowOptions(),
     ) -> WorkflowVersion:
         try:
@@ -410,7 +410,7 @@ class AdminClient(AdminClientBase):
         self,
         name: str,
         schedules: list[Union[datetime, timestamp_pb2.Timestamp]],
-        input: Input = {},
+        input: JSONSerializableDict = {},
         options: ScheduleTriggerWorkflowOptions = ScheduleTriggerWorkflowOptions(),
     ) -> WorkflowVersion:
         try:
@@ -442,7 +442,7 @@ class AdminClient(AdminClientBase):
     def run_workflow(
         self,
         workflow_name: str,
-        input: Input,
+        input: JSONSerializableDict,
         options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
     ) -> WorkflowRunRef:
         ctx = parse_carrier_from_metadata(options.additional_metadata)
@@ -542,7 +542,7 @@ class AdminClient(AdminClientBase):
     def run(
         self,
         function: Union[str, Callable[[Any], T]],
-        input: Input,
+        input: JSONSerializableDict,
         options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
     ) -> "RunRef[T]":
         workflow_name = cast(

--- a/hatchet_sdk/clients/dispatcher/action_listener.py
+++ b/hatchet_sdk/clients/dispatcher/action_listener.py
@@ -24,7 +24,7 @@ from hatchet_sdk.contracts.dispatcher_pb2_grpc import DispatcherStub
 from hatchet_sdk.logger import logger
 from hatchet_sdk.utils.backoff import exp_backoff_sleep
 from hatchet_sdk.utils.serialization import flatten
-from hatchet_sdk.utils.types import AdditionalMetadata
+from hatchet_sdk.utils.types import JSONSerializableDict
 
 from ...loader import ClientConfig
 from ...metadata import get_metadata
@@ -72,7 +72,7 @@ class Action:
     action_payload: str
     action_type: ActionType
     retry_count: int
-    additional_metadata: AdditionalMetadata = field(default_factory=dict)
+    additional_metadata: JSONSerializableDict = field(default_factory=dict)
 
     child_workflow_index: int | None = None
     child_workflow_key: str | None = None

--- a/hatchet_sdk/clients/dispatcher/action_listener.py
+++ b/hatchet_sdk/clients/dispatcher/action_listener.py
@@ -24,6 +24,7 @@ from hatchet_sdk.contracts.dispatcher_pb2_grpc import DispatcherStub
 from hatchet_sdk.logger import logger
 from hatchet_sdk.utils.backoff import exp_backoff_sleep
 from hatchet_sdk.utils.serialization import flatten
+from hatchet_sdk.utils.types import AdditionalMetadata
 
 from ...loader import ClientConfig
 from ...metadata import get_metadata
@@ -71,7 +72,7 @@ class Action:
     action_payload: str
     action_type: ActionType
     retry_count: int
-    additional_metadata: dict[str, str] | None = None
+    additional_metadata: AdditionalMetadata = {}
 
     child_workflow_index: int | None = None
     child_workflow_key: str | None = None

--- a/hatchet_sdk/clients/dispatcher/action_listener.py
+++ b/hatchet_sdk/clients/dispatcher/action_listener.py
@@ -72,7 +72,7 @@ class Action:
     action_payload: str
     action_type: ActionType
     retry_count: int
-    additional_metadata: AdditionalMetadata = {}
+    additional_metadata: AdditionalMetadata = field(default_factory=dict)
 
     child_workflow_index: int | None = None
     child_workflow_key: str | None = None

--- a/hatchet_sdk/clients/events.py
+++ b/hatchet_sdk/clients/events.py
@@ -129,8 +129,8 @@ class EventClient:
             span.add_event("Pushing event", attributes={"key": namespaced_event_key})
 
             return cast(
-                    Event, self.client.Push(request, metadata=get_metadata(self.token))
-                )
+                Event, self.client.Push(request, metadata=get_metadata(self.token))
+            )
 
     @tenacity_retry
     def bulk_push(
@@ -183,9 +183,9 @@ class EventClient:
         response = self.client.BulkPush(bulk_request, metadata=get_metadata(self.token))
 
         return cast(
-                list[Event],
-                response.events,
-            )
+            list[Event],
+            response.events,
+        )
 
     def log(self, message: str, step_run_id: str) -> None:
         try:

--- a/hatchet_sdk/clients/events.py
+++ b/hatchet_sdk/clients/events.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import grpc
 from google.protobuf import timestamp_pb2
+from pydantic import BaseModel
 
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
 from hatchet_sdk.contracts.events_pb2 import (
@@ -23,6 +24,7 @@ from hatchet_sdk.utils.tracing import (
     inject_carrier_into_metadata,
     parse_carrier_from_metadata,
 )
+from hatchet_sdk.utils.types import AdditionalMetadata
 
 from ..loader import ClientConfig
 from ..metadata import get_metadata
@@ -43,19 +45,19 @@ def proto_timestamp_now():
     return timestamp_pb2.Timestamp(seconds=seconds, nanos=nanos)
 
 
-class PushEventOptions(TypedDict, total=False):
-    additional_metadata: Dict[str, str] | None = None
+class PushEventOptions(BaseModel):
+    additional_metadata: AdditionalMetadata = {}
     namespace: str | None = None
 
 
-class BulkPushEventOptions(TypedDict, total=False):
+class BulkPushEventOptions(BaseModel):
     namespace: str | None = None
 
 
-class BulkPushEventWithMetadata(TypedDict, total=False):
+class BulkPushEventWithMetadata(BaseModel):
     key: str
     payload: Any
-    additional_metadata: Optional[Dict[str, Any]]  # Optional metadata
+    additional_metadata: AdditionalMetadata = {}
 
 
 class EventClient:

--- a/hatchet_sdk/clients/events.py
+++ b/hatchet_sdk/clients/events.py
@@ -25,7 +25,7 @@ from hatchet_sdk.utils.tracing import (
     inject_carrier_into_metadata,
     parse_carrier_from_metadata,
 )
-from hatchet_sdk.utils.types import AdditionalMetadata
+from hatchet_sdk.utils.types import JSONSerializableDict
 
 from ..loader import ClientConfig
 from ..metadata import get_metadata
@@ -47,7 +47,7 @@ def proto_timestamp_now() -> timestamp_pb2.Timestamp:
 
 
 class PushEventOptions(BaseModel):
-    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
+    additional_metadata: JSONSerializableDict = Field(default_factory=dict)
     namespace: str | None = None
 
 
@@ -59,7 +59,7 @@ class BulkPushEventOptions(BaseModel):
 class BulkPushEventWithMetadata(BaseModel):
     key: str
     payload: Any
-    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
+    additional_metadata: JSONSerializableDict = Field(default_factory=dict)
 
 
 class EventClient:

--- a/hatchet_sdk/clients/events.py
+++ b/hatchet_sdk/clients/events.py
@@ -1,7 +1,7 @@
 import asyncio
 import datetime
 import json
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict, cast
 from uuid import uuid4
 
 import grpc
@@ -19,6 +19,7 @@ from hatchet_sdk.contracts.events_pb2 import (
 from hatchet_sdk.contracts.events_pb2_grpc import EventsServiceStub
 from hatchet_sdk.utils.serialization import flatten
 from hatchet_sdk.utils.tracing import (
+    OTEL_CARRIER_KEY,
     create_carrier,
     create_tracer,
     inject_carrier_into_metadata,
@@ -30,14 +31,14 @@ from ..loader import ClientConfig
 from ..metadata import get_metadata
 
 
-def new_event(conn, config: ClientConfig):
+def new_event(conn: grpc.Channel, config: ClientConfig) -> "EventClient":
     return EventClient(
-        client=EventsServiceStub(conn),
+        client=EventsServiceStub(conn),  # type: ignore[no-untyped-call]
         config=config,
     )
 
 
-def proto_timestamp_now():
+def proto_timestamp_now() -> timestamp_pb2.Timestamp:
     t = datetime.datetime.now().timestamp()
     seconds = int(t)
     nanos = int(t % 1 * 1e9)
@@ -52,6 +53,7 @@ class PushEventOptions(BaseModel):
 
 class BulkPushEventOptions(BaseModel):
     namespace: str | None = None
+    otel_carrier: dict[str, str] = Field(default_factory=dict)
 
 
 class BulkPushEventWithMetadata(BaseModel):
@@ -68,7 +70,10 @@ class EventClient:
         self.otel_tracer = create_tracer(config=config)
 
     async def async_push(
-        self, event_key, payload, options: Optional[PushEventOptions] = None
+        self,
+        event_key: str,
+        payload: dict[str, Any],
+        options: PushEventOptions = PushEventOptions(),
     ) -> Event:
         return await asyncio.to_thread(
             self.push, event_key=event_key, payload=payload, options=options
@@ -76,51 +81,47 @@ class EventClient:
 
     async def async_bulk_push(
         self,
-        events: List[BulkPushEventWithMetadata],
-        options: Optional[BulkPushEventOptions] = None,
+        events: list[BulkPushEventWithMetadata],
+        options: BulkPushEventOptions = BulkPushEventOptions(),
     ) -> List[Event]:
         return await asyncio.to_thread(self.bulk_push, events=events, options=options)
 
     @tenacity_retry
-    def push(self, event_key, payload, options: PushEventOptions = None) -> Event:
-        ctx = parse_carrier_from_metadata(
-            (options or {}).get("additional_metadata", {})
-        )
+    def push(
+        self,
+        event_key: str,
+        payload: dict[str, Any],
+        options: PushEventOptions = PushEventOptions(),
+    ) -> Event:
+        ctx = parse_carrier_from_metadata(options.additional_metadata)
 
         with self.otel_tracer.start_as_current_span(
             "hatchet.push", context=ctx
         ) as span:
             carrier = create_carrier()
-            namespace = self.namespace
-
-            if (
-                options is not None
-                and "namespace" in options
-                and options["namespace"] is not None
-            ):
-                namespace = options.pop("namespace")
+            namespace = options.namespace or self.namespace
 
             namespaced_event_key = namespace + event_key
 
             try:
                 meta = inject_carrier_into_metadata(
-                    dict() if options is None else options["additional_metadata"],
+                    options.additional_metadata,
                     carrier,
                 )
-                meta_bytes = None if meta is None else json.dumps(meta).encode("utf-8")
+                meta_bytes = None if meta is None else json.dumps(meta)
             except Exception as e:
                 raise ValueError(f"Error encoding meta: {e}")
 
             span.set_attributes(flatten(meta, parent_key="", separator="."))
 
             try:
-                payload_bytes = json.dumps(payload).encode("utf-8")
-            except json.UnicodeEncodeError as e:
+                payload_str = json.dumps(payload)
+            except (TypeError, ValueError) as e:
                 raise ValueError(f"Error encoding payload: {e}")
 
             request = PushEventRequest(
                 key=namespaced_event_key,
-                payload=payload_bytes,
+                payload=payload_str,
                 eventTimestamp=proto_timestamp_now(),
                 additionalMetadata=meta_bytes,
             )
@@ -128,7 +129,9 @@ class EventClient:
             span.add_event("Pushing event", attributes={"key": namespaced_event_key})
 
             try:
-                return self.client.Push(request, metadata=get_metadata(self.token))
+                return cast(
+                    Event, self.client.Push(request, metadata=get_metadata(self.token))
+                )
             except grpc.RpcError as e:
                 raise ValueError(f"gRPC error: {e}")
 
@@ -136,20 +139,12 @@ class EventClient:
     def bulk_push(
         self,
         events: List[BulkPushEventWithMetadata],
-        options: BulkPushEventOptions = None,
+        options: BulkPushEventOptions,
     ) -> List[Event]:
-        namespace = self.namespace
+        namespace = options.namespace or self.namespace
         bulk_push_correlation_id = uuid4()
-        ctx = parse_carrier_from_metadata(
-            (options or {}).get("additional_metadata", {})
-        )
 
-        if (
-            options is not None
-            and "namespace" in options
-            and options["namespace"] is not None
-        ):
-            namespace = options.pop("namespace")
+        ctx = parse_carrier_from_metadata({OTEL_CARRIER_KEY: options.otel_carrier})
 
         bulk_events = []
         for event in events:
@@ -161,29 +156,27 @@ class EventClient:
                     "bulk_push_correlation_id", str(bulk_push_correlation_id)
                 )
 
-                event_key = namespace + event["key"]
-                payload = event["payload"]
+                event_key = namespace + event.key
+                payload = event.payload
 
-                try:
-                    meta = inject_carrier_into_metadata(
-                        event.get("additional_metadata", {}), carrier
-                    )
-                    meta_bytes = json.dumps(meta).encode("utf-8") if meta else None
-                except Exception as e:
-                    raise ValueError(f"Error encoding meta: {e}")
-
+                meta = inject_carrier_into_metadata(event.additional_metadata, carrier)
                 span.set_attributes(flatten(meta, parent_key="", separator="."))
 
                 try:
-                    payload_bytes = json.dumps(payload).encode("utf-8")
-                except json.UnicodeEncodeError as e:
+                    meta_str = json.dumps(meta)
+                except Exception as e:
+                    raise ValueError(f"Error encoding meta: {e}")
+
+                try:
+                    payload = json.dumps(payload)
+                except (TypeError, ValueError) as e:
                     raise ValueError(f"Error encoding payload: {e}")
 
                 request = PushEventRequest(
                     key=event_key,
-                    payload=payload_bytes,
+                    payload=payload,
                     eventTimestamp=proto_timestamp_now(),
-                    additionalMetadata=meta_bytes,
+                    additionalMetadata=meta_str,
                 )
                 bulk_events.append(request)
 
@@ -194,11 +187,14 @@ class EventClient:
             response = self.client.BulkPush(
                 bulk_request, metadata=get_metadata(self.token)
             )
-            return response.events
+            return cast(
+                list[Event],
+                response.events,
+            )
         except grpc.RpcError as e:
             raise ValueError(f"gRPC error: {e}")
 
-    def log(self, message: str, step_run_id: str):
+    def log(self, message: str, step_run_id: str) -> None:
         try:
             request = PutLogRequest(
                 stepRunId=step_run_id,
@@ -210,7 +206,7 @@ class EventClient:
         except Exception as e:
             raise ValueError(f"Error logging: {e}")
 
-    def stream(self, data: str | bytes, step_run_id: str):
+    def stream(self, data: str | bytes, step_run_id: str) -> None:
         try:
             if isinstance(data, str):
                 data_bytes = data.encode("utf-8")

--- a/hatchet_sdk/clients/events.py
+++ b/hatchet_sdk/clients/events.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import grpc
 from google.protobuf import timestamp_pb2
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
 from hatchet_sdk.contracts.events_pb2 import (
@@ -46,7 +46,7 @@ def proto_timestamp_now():
 
 
 class PushEventOptions(BaseModel):
-    additional_metadata: AdditionalMetadata = {}
+    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
     namespace: str | None = None
 
 
@@ -57,7 +57,7 @@ class BulkPushEventOptions(BaseModel):
 class BulkPushEventWithMetadata(BaseModel):
     key: str
     payload: Any
-    additional_metadata: AdditionalMetadata = {}
+    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
 
 
 class EventClient:

--- a/hatchet_sdk/clients/rest_client.py
+++ b/hatchet_sdk/clients/rest_client.py
@@ -66,6 +66,7 @@ from hatchet_sdk.clients.rest.models.workflow_runs_cancel_request import (
     WorkflowRunsCancelRequest,
 )
 from hatchet_sdk.clients.rest.models.workflow_version import WorkflowVersion
+from hatchet_sdk.utils.types import AdditionalMetadata
 
 
 class AsyncRestApi:
@@ -230,7 +231,7 @@ class AsyncRestApi:
         cron_name: str,
         expression: str,
         input: dict[str, Any],
-        additional_metadata: dict[str, str],
+        additional_metadata: AdditionalMetadata,
     ):
         return await self.workflow_run_api.cron_workflow_trigger_create(
             tenant=self.tenant_id,
@@ -279,7 +280,7 @@ class AsyncRestApi:
         name: str,
         trigger_at: datetime.datetime,
         input: dict[str, Any],
-        additional_metadata: dict[str, str],
+        additional_metadata: AdditionalMetadata,
     ):
         return await self.workflow_run_api.scheduled_workflow_run_create(
             tenant=self.tenant_id,
@@ -486,7 +487,7 @@ class RestApi:
         cron_name: str,
         expression: str,
         input: dict[str, Any],
-        additional_metadata: dict[str, str],
+        additional_metadata: AdditionalMetadata,
     ) -> CronWorkflows:
         return self._run_coroutine(
             self.aio.cron_create(
@@ -525,7 +526,7 @@ class RestApi:
         workflow_name: str,
         trigger_at: datetime.datetime,
         input: dict[str, Any],
-        additional_metadata: dict[str, str],
+        additional_metadata: AdditionalMetadata,
     ):
         return self._run_coroutine(
             self.aio.schedule_create(

--- a/hatchet_sdk/clients/rest_client.py
+++ b/hatchet_sdk/clients/rest_client.py
@@ -66,7 +66,7 @@ from hatchet_sdk.clients.rest.models.workflow_runs_cancel_request import (
     WorkflowRunsCancelRequest,
 )
 from hatchet_sdk.clients.rest.models.workflow_version import WorkflowVersion
-from hatchet_sdk.utils.types import AdditionalMetadata, Input
+from hatchet_sdk.utils.types import JSONSerializableDict
 
 
 class AsyncRestApi:
@@ -212,7 +212,7 @@ class AsyncRestApi:
     async def workflow_run_create(
         self,
         workflow_id: str,
-        input: Input,
+        input: JSONSerializableDict,
         version: str | None = None,
         additional_metadata: list[str] | None = None,
     ) -> WorkflowRun:
@@ -230,8 +230,8 @@ class AsyncRestApi:
         workflow_name: str,
         cron_name: str,
         expression: str,
-        input: Input,
-        additional_metadata: AdditionalMetadata,
+        input: JSONSerializableDict,
+        additional_metadata: JSONSerializableDict,
     ):
         return await self.workflow_run_api.cron_workflow_trigger_create(
             tenant=self.tenant_id,
@@ -279,8 +279,8 @@ class AsyncRestApi:
         self,
         name: str,
         trigger_at: datetime.datetime,
-        input: Input,
-        additional_metadata: AdditionalMetadata,
+        input: JSONSerializableDict,
+        additional_metadata: JSONSerializableDict,
     ):
         return await self.workflow_run_api.scheduled_workflow_run_create(
             tenant=self.tenant_id,
@@ -471,7 +471,7 @@ class RestApi:
     def workflow_run_create(
         self,
         workflow_id: str,
-        input: Input,
+        input: JSONSerializableDict,
         version: str | None = None,
         additional_metadata: list[str] | None = None,
     ) -> WorkflowRun:
@@ -486,8 +486,8 @@ class RestApi:
         workflow_name: str,
         cron_name: str,
         expression: str,
-        input: Input,
-        additional_metadata: AdditionalMetadata,
+        input: JSONSerializableDict,
+        additional_metadata: JSONSerializableDict,
     ) -> CronWorkflows:
         return self._run_coroutine(
             self.aio.cron_create(
@@ -525,8 +525,8 @@ class RestApi:
         self,
         workflow_name: str,
         trigger_at: datetime.datetime,
-        input: Input,
-        additional_metadata: AdditionalMetadata,
+        input: JSONSerializableDict,
+        additional_metadata: JSONSerializableDict,
     ):
         return self._run_coroutine(
             self.aio.schedule_create(

--- a/hatchet_sdk/clients/rest_client.py
+++ b/hatchet_sdk/clients/rest_client.py
@@ -66,7 +66,7 @@ from hatchet_sdk.clients.rest.models.workflow_runs_cancel_request import (
     WorkflowRunsCancelRequest,
 )
 from hatchet_sdk.clients.rest.models.workflow_version import WorkflowVersion
-from hatchet_sdk.utils.types import AdditionalMetadata
+from hatchet_sdk.utils.types import AdditionalMetadata, Input
 
 
 class AsyncRestApi:
@@ -212,7 +212,7 @@ class AsyncRestApi:
     async def workflow_run_create(
         self,
         workflow_id: str,
-        input: dict[str, Any],
+        input: Input,
         version: str | None = None,
         additional_metadata: list[str] | None = None,
     ) -> WorkflowRun:
@@ -230,7 +230,7 @@ class AsyncRestApi:
         workflow_name: str,
         cron_name: str,
         expression: str,
-        input: dict[str, Any],
+        input: Input,
         additional_metadata: AdditionalMetadata,
     ):
         return await self.workflow_run_api.cron_workflow_trigger_create(
@@ -279,7 +279,7 @@ class AsyncRestApi:
         self,
         name: str,
         trigger_at: datetime.datetime,
-        input: dict[str, Any],
+        input: Input,
         additional_metadata: AdditionalMetadata,
     ):
         return await self.workflow_run_api.scheduled_workflow_run_create(
@@ -471,7 +471,7 @@ class RestApi:
     def workflow_run_create(
         self,
         workflow_id: str,
-        input: dict[str, Any],
+        input: Input,
         version: str | None = None,
         additional_metadata: list[str] | None = None,
     ) -> WorkflowRun:
@@ -486,7 +486,7 @@ class RestApi:
         workflow_name: str,
         cron_name: str,
         expression: str,
-        input: dict[str, Any],
+        input: Input,
         additional_metadata: AdditionalMetadata,
     ) -> CronWorkflows:
         return self._run_coroutine(
@@ -525,7 +525,7 @@ class RestApi:
         self,
         workflow_name: str,
         trigger_at: datetime.datetime,
-        input: dict[str, Any],
+        input: Input,
         additional_metadata: AdditionalMetadata,
     ):
         return self._run_coroutine(

--- a/hatchet_sdk/context/context.py
+++ b/hatchet_sdk/context/context.py
@@ -18,7 +18,7 @@ from hatchet_sdk.contracts.workflows_pb2 import (
     BulkTriggerWorkflowRequest,
     TriggerWorkflowRequest,
 )
-from hatchet_sdk.utils.types import WorkflowValidator
+from hatchet_sdk.utils.types import Input, WorkflowValidator
 from hatchet_sdk.utils.typing import is_basemodel_subclass
 from hatchet_sdk.workflow_run import WorkflowRunRef
 
@@ -101,7 +101,7 @@ class ContextAioImpl(BaseContext):
     async def spawn_workflow(
         self,
         workflow_name: str,
-        input: dict[str, Any] = {},
+        input: Input = {},
         key: str | None = None,
         options: ChildTriggerWorkflowOptions = ChildTriggerWorkflowOptions(),
     ) -> WorkflowRunRef:
@@ -126,7 +126,7 @@ class ContextAioImpl(BaseContext):
         bulk_trigger_workflow_runs = [
             WorkflowRunDict(
                 workflow_name=child_workflow_run.workflow_name,
-                input=input,
+                input=child_workflow_run.input,
                 options=self._prepare_workflow_options(
                     child_workflow_run.key, child_workflow_run.options, worker_id
                 ),

--- a/hatchet_sdk/context/context.py
+++ b/hatchet_sdk/context/context.py
@@ -18,7 +18,7 @@ from hatchet_sdk.contracts.workflows_pb2 import (
     BulkTriggerWorkflowRequest,
     TriggerWorkflowRequest,
 )
-from hatchet_sdk.utils.types import Input, WorkflowValidator
+from hatchet_sdk.utils.types import JSONSerializableDict, WorkflowValidator
 from hatchet_sdk.utils.typing import is_basemodel_subclass
 from hatchet_sdk.workflow_run import WorkflowRunRef
 
@@ -101,7 +101,7 @@ class ContextAioImpl(BaseContext):
     async def spawn_workflow(
         self,
         workflow_name: str,
-        input: Input = {},
+        input: JSONSerializableDict = {},
         key: str | None = None,
         options: ChildTriggerWorkflowOptions = ChildTriggerWorkflowOptions(),
     ) -> WorkflowRunRef:

--- a/hatchet_sdk/features/cron.py
+++ b/hatchet_sdk/features/cron.py
@@ -11,10 +11,10 @@ from hatchet_sdk.clients.rest.models.cron_workflows_order_by_field import (
 from hatchet_sdk.clients.rest.models.workflow_run_order_by_direction import (
     WorkflowRunOrderByDirection,
 )
-from hatchet_sdk.utils.types import AdditionalMetadata, Input
+from hatchet_sdk.utils.types import JSONSerializableDict
 
 
-class CreateCronTriggerInput(BaseModel):
+class CreateCronTriggerJSONSerializableDict(BaseModel):
     """
     Schema for creating a workflow run triggered by a cron.
 
@@ -25,8 +25,8 @@ class CreateCronTriggerInput(BaseModel):
     """
 
     expression: str = None
-    input: Input = Field(default_factory=dict)
-    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
+    input: JSONSerializableDict = Field(default_factory=dict)
+    additional_metadata: JSONSerializableDict = Field(default_factory=dict)
 
     @field_validator("expression")
     def validate_cron_expression(cls, v):
@@ -87,8 +87,8 @@ class CronClient:
         workflow_name: str,
         cron_name: str,
         expression: str,
-        input: Input,
-        additional_metadata: AdditionalMetadata,
+        input: JSONSerializableDict,
+        additional_metadata: JSONSerializableDict,
     ) -> CronWorkflows:
         """
         Creates a new workflow cron trigger.
@@ -103,7 +103,7 @@ class CronClient:
         Returns:
             CronWorkflows: The created cron workflow instance.
         """
-        validated_input = CreateCronTriggerInput(
+        validated_input = CreateCronTriggerJSONSerializableDict(
             expression=expression, input=input, additional_metadata=additional_metadata
         )
 
@@ -199,8 +199,8 @@ class CronClientAsync:
         workflow_name: str,
         cron_name: str,
         expression: str,
-        input: Input,
-        additional_metadata: AdditionalMetadata,
+        input: JSONSerializableDict,
+        additional_metadata: JSONSerializableDict,
     ) -> CronWorkflows:
         """
         Asynchronously creates a new workflow cron trigger.
@@ -215,7 +215,7 @@ class CronClientAsync:
         Returns:
             CronWorkflows: The created cron workflow instance.
         """
-        validated_input = CreateCronTriggerInput(
+        validated_input = CreateCronTriggerJSONSerializableDict(
             expression=expression, input=input, additional_metadata=additional_metadata
         )
 

--- a/hatchet_sdk/features/cron.py
+++ b/hatchet_sdk/features/cron.py
@@ -11,7 +11,7 @@ from hatchet_sdk.clients.rest.models.cron_workflows_order_by_field import (
 from hatchet_sdk.clients.rest.models.workflow_run_order_by_direction import (
     WorkflowRunOrderByDirection,
 )
-from hatchet_sdk.utils.types import AdditionalMetadata
+from hatchet_sdk.utils.types import AdditionalMetadata, Input
 
 
 class CreateCronTriggerInput(BaseModel):
@@ -25,7 +25,7 @@ class CreateCronTriggerInput(BaseModel):
     """
 
     expression: str = None
-    input: dict[str, Any] = Field(default_factory=dict)
+    input: Input = Field(default_factory=dict)
     additional_metadata: AdditionalMetadata = Field(default_factory=dict)
 
     @field_validator("expression")
@@ -87,7 +87,7 @@ class CronClient:
         workflow_name: str,
         cron_name: str,
         expression: str,
-        input: dict,
+        input: Input,
         additional_metadata: AdditionalMetadata,
     ) -> CronWorkflows:
         """
@@ -199,7 +199,7 @@ class CronClientAsync:
         workflow_name: str,
         cron_name: str,
         expression: str,
-        input: dict,
+        input: Input,
         additional_metadata: AdditionalMetadata,
     ) -> CronWorkflows:
         """

--- a/hatchet_sdk/features/cron.py
+++ b/hatchet_sdk/features/cron.py
@@ -11,6 +11,7 @@ from hatchet_sdk.clients.rest.models.cron_workflows_order_by_field import (
 from hatchet_sdk.clients.rest.models.workflow_run_order_by_direction import (
     WorkflowRunOrderByDirection,
 )
+from hatchet_sdk.utils.types import AdditionalMetadata
 
 
 class CreateCronTriggerInput(BaseModel):
@@ -25,7 +26,7 @@ class CreateCronTriggerInput(BaseModel):
 
     expression: str = None
     input: dict = {}
-    additional_metadata: dict[str, str] = {}
+    additional_metadata: AdditionalMetadata = {}
 
     @field_validator("expression")
     def validate_cron_expression(cls, v):
@@ -87,7 +88,7 @@ class CronClient:
         cron_name: str,
         expression: str,
         input: dict,
-        additional_metadata: dict[str, str],
+        additional_metadata: AdditionalMetadata,
     ) -> CronWorkflows:
         """
         Creates a new workflow cron trigger.
@@ -199,7 +200,7 @@ class CronClientAsync:
         cron_name: str,
         expression: str,
         input: dict,
-        additional_metadata: dict[str, str],
+        additional_metadata: AdditionalMetadata,
     ) -> CronWorkflows:
         """
         Asynchronously creates a new workflow cron trigger.

--- a/hatchet_sdk/features/cron.py
+++ b/hatchet_sdk/features/cron.py
@@ -1,6 +1,6 @@
-from typing import Union
+from typing import Any, Union
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from hatchet_sdk.client import Client
 from hatchet_sdk.clients.rest.models.cron_workflows import CronWorkflows
@@ -25,8 +25,8 @@ class CreateCronTriggerInput(BaseModel):
     """
 
     expression: str = None
-    input: dict = {}
-    additional_metadata: AdditionalMetadata = {}
+    input: dict[str, Any] = Field(default_factory=dict)
+    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
 
     @field_validator("expression")
     def validate_cron_expression(cls, v):

--- a/hatchet_sdk/features/scheduled.py
+++ b/hatchet_sdk/features/scheduled.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any, Coroutine, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from hatchet_sdk.client import Client
 from hatchet_sdk.clients.rest.models.cron_workflows import CronWorkflows
@@ -28,9 +28,9 @@ class CreateScheduledTriggerInput(BaseModel):
         trigger_at (Optional[datetime.datetime]): The datetime when the run should be triggered.
     """
 
-    input: Dict[str, Any] = {}
-    additional_metadata: AdditionalMetadata = {}
-    trigger_at: Optional[datetime.datetime] = None
+    input: dict[str, Any] = Field(default_factory=dict)
+    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
+    trigger_at: datetime.datetime | None = None
 
 
 class ScheduledClient:
@@ -168,8 +168,8 @@ class ScheduledClientAsync:
         self,
         workflow_name: str,
         trigger_at: datetime.datetime,
-        input: Dict[str, Any],
-        additional_metadata: AdditionalMetadatan,
+        input: dict[str, Any],
+        additional_metadata: AdditionalMetadata,
     ) -> ScheduledWorkflows:
         """
         Creates a new scheduled workflow run asynchronously.

--- a/hatchet_sdk/features/scheduled.py
+++ b/hatchet_sdk/features/scheduled.py
@@ -15,7 +15,7 @@ from hatchet_sdk.clients.rest.models.scheduled_workflows_list import (
 from hatchet_sdk.clients.rest.models.workflow_run_order_by_direction import (
     WorkflowRunOrderByDirection,
 )
-from hatchet_sdk.utils.types import AdditionalMetadata
+from hatchet_sdk.utils.types import AdditionalMetadata, Input
 
 
 class CreateScheduledTriggerInput(BaseModel):
@@ -28,7 +28,7 @@ class CreateScheduledTriggerInput(BaseModel):
         trigger_at (Optional[datetime.datetime]): The datetime when the run should be triggered.
     """
 
-    input: dict[str, Any] = Field(default_factory=dict)
+    input: Input = Field(default_factory=dict)
     additional_metadata: AdditionalMetadata = Field(default_factory=dict)
     trigger_at: datetime.datetime | None = None
 
@@ -58,7 +58,7 @@ class ScheduledClient:
         self,
         workflow_name: str,
         trigger_at: datetime.datetime,
-        input: Dict[str, Any],
+        input: Input,
         additional_metadata: AdditionalMetadata,
     ) -> ScheduledWorkflows:
         """
@@ -168,7 +168,7 @@ class ScheduledClientAsync:
         self,
         workflow_name: str,
         trigger_at: datetime.datetime,
-        input: dict[str, Any],
+        input: Input,
         additional_metadata: AdditionalMetadata,
     ) -> ScheduledWorkflows:
         """

--- a/hatchet_sdk/features/scheduled.py
+++ b/hatchet_sdk/features/scheduled.py
@@ -15,6 +15,7 @@ from hatchet_sdk.clients.rest.models.scheduled_workflows_list import (
 from hatchet_sdk.clients.rest.models.workflow_run_order_by_direction import (
     WorkflowRunOrderByDirection,
 )
+from hatchet_sdk.utils.types import AdditionalMetadata
 
 
 class CreateScheduledTriggerInput(BaseModel):
@@ -28,7 +29,7 @@ class CreateScheduledTriggerInput(BaseModel):
     """
 
     input: Dict[str, Any] = {}
-    additional_metadata: Dict[str, str] = {}
+    additional_metadata: AdditionalMetadata = {}
     trigger_at: Optional[datetime.datetime] = None
 
 
@@ -58,7 +59,7 @@ class ScheduledClient:
         workflow_name: str,
         trigger_at: datetime.datetime,
         input: Dict[str, Any],
-        additional_metadata: Dict[str, str],
+        additional_metadata: AdditionalMetadata,
     ) -> ScheduledWorkflows:
         """
         Creates a new scheduled workflow run asynchronously.
@@ -168,7 +169,7 @@ class ScheduledClientAsync:
         workflow_name: str,
         trigger_at: datetime.datetime,
         input: Dict[str, Any],
-        additional_metadata: Dict[str, str],
+        additional_metadata: AdditionalMetadatan,
     ) -> ScheduledWorkflows:
         """
         Creates a new scheduled workflow run asynchronously.

--- a/hatchet_sdk/features/scheduled.py
+++ b/hatchet_sdk/features/scheduled.py
@@ -15,10 +15,10 @@ from hatchet_sdk.clients.rest.models.scheduled_workflows_list import (
 from hatchet_sdk.clients.rest.models.workflow_run_order_by_direction import (
     WorkflowRunOrderByDirection,
 )
-from hatchet_sdk.utils.types import AdditionalMetadata, Input
+from hatchet_sdk.utils.types import JSONSerializableDict
 
 
-class CreateScheduledTriggerInput(BaseModel):
+class CreateScheduledTriggerJSONSerializableDict(BaseModel):
     """
     Schema for creating a scheduled workflow run.
 
@@ -28,8 +28,8 @@ class CreateScheduledTriggerInput(BaseModel):
         trigger_at (Optional[datetime.datetime]): The datetime when the run should be triggered.
     """
 
-    input: Input = Field(default_factory=dict)
-    additional_metadata: AdditionalMetadata = Field(default_factory=dict)
+    input: JSONSerializableDict = Field(default_factory=dict)
+    additional_metadata: JSONSerializableDict = Field(default_factory=dict)
     trigger_at: datetime.datetime | None = None
 
 
@@ -58,8 +58,8 @@ class ScheduledClient:
         self,
         workflow_name: str,
         trigger_at: datetime.datetime,
-        input: Input,
-        additional_metadata: AdditionalMetadata,
+        input: JSONSerializableDict,
+        additional_metadata: JSONSerializableDict,
     ) -> ScheduledWorkflows:
         """
         Creates a new scheduled workflow run asynchronously.
@@ -74,7 +74,7 @@ class ScheduledClient:
             ScheduledWorkflows: The created scheduled workflow instance.
         """
 
-        validated_input = CreateScheduledTriggerInput(
+        validated_input = CreateScheduledTriggerJSONSerializableDict(
             trigger_at=trigger_at, input=input, additional_metadata=additional_metadata
         )
 
@@ -168,8 +168,8 @@ class ScheduledClientAsync:
         self,
         workflow_name: str,
         trigger_at: datetime.datetime,
-        input: Input,
-        additional_metadata: AdditionalMetadata,
+        input: JSONSerializableDict,
+        additional_metadata: JSONSerializableDict,
     ) -> ScheduledWorkflows:
         """
         Creates a new scheduled workflow run asynchronously.

--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -12,6 +12,7 @@ from hatchet_sdk.contracts.workflows_pb2 import (
     CreateStepRateLimit,
     DesiredWorkerLabels,
     StickyStrategy,
+    WorkerLabelComparator,
 )
 from hatchet_sdk.features.cron import CronClient
 from hatchet_sdk.features.scheduled import ScheduledClient
@@ -107,13 +108,13 @@ def step(
         setattr(func, "_step_backoff_max_seconds", backoff_max_seconds)
 
         def create_label(d: DesiredWorkerLabel) -> DesiredWorkerLabels:
-            value = d["value"] if "value" in d else None
+            value = d.value
             return DesiredWorkerLabels(
-                strValue=str(value) if not isinstance(value, int) else None,
+                strValue=value if not isinstance(value, int) else None,
                 intValue=value if isinstance(value, int) else None,
-                required=d["required"] if "required" in d else None,  # type: ignore[arg-type]
-                weight=d["weight"] if "weight" in d else None,
-                comparator=d["comparator"] if "comparator" in d else None,  # type: ignore[arg-type]
+                required=d.required,
+                weight=d.weight,
+                comparator=d.comparator,
             )
 
         setattr(

--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -114,7 +114,7 @@ def step(
                 intValue=value if isinstance(value, int) else None,
                 required=d.required,
                 weight=d.weight,
-                comparator=d.comparator,
+                comparator=d.comparator,  # type: ignore[arg-type]
             )
 
         setattr(

--- a/hatchet_sdk/labels.py
+++ b/hatchet_sdk/labels.py
@@ -1,10 +1,10 @@
-from pydantic import BaseModel
-
-from hatchet_sdk.contracts.workflows_pb2 import WorkerLabelComparator
+from pydantic import BaseModel, ConfigDict
 
 
 class DesiredWorkerLabel(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     value: str | int
     required: bool = False
     weight: int | None = None
-    comparator: WorkerLabelComparator | None = None
+    comparator: int | None = None

--- a/hatchet_sdk/labels.py
+++ b/hatchet_sdk/labels.py
@@ -1,10 +1,10 @@
-from typing import TypedDict
+from pydantic import BaseModel
+
+from hatchet_sdk.contracts.workflows_pb2 import WorkerLabelComparator
 
 
-class DesiredWorkerLabel(TypedDict, total=False):
+class DesiredWorkerLabel(BaseModel):
     value: str | int
-    required: bool | None = None
+    required: bool = False
     weight: int | None = None
-    comparator: int | None = (
-        None  # _ClassVar[WorkerLabelComparator] TODO figure out type
-    )
+    comparator: WorkerLabelComparator | None = None

--- a/hatchet_sdk/utils/types.py
+++ b/hatchet_sdk/utils/types.py
@@ -8,5 +8,4 @@ class WorkflowValidator(BaseModel):
     step_output: Type[BaseModel] | None = None
 
 
-AdditionalMetadata = dict[str, Any]
-Input = dict[str, Any]
+JSONSerializableDict = dict[str, Any]

--- a/hatchet_sdk/utils/types.py
+++ b/hatchet_sdk/utils/types.py
@@ -8,4 +8,5 @@ class WorkflowValidator(BaseModel):
     step_output: Type[BaseModel] | None = None
 
 
-AdditionalMetadata = dict[str, str]
+AdditionalMetadata = dict[str, Any]
+Input = dict[str, Any]

--- a/hatchet_sdk/utils/types.py
+++ b/hatchet_sdk/utils/types.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Any, Type
 
 from pydantic import BaseModel
 

--- a/hatchet_sdk/utils/types.py
+++ b/hatchet_sdk/utils/types.py
@@ -6,3 +6,6 @@ from pydantic import BaseModel
 class WorkflowValidator(BaseModel):
     workflow_input: Type[BaseModel] | None = None
     step_output: Type[BaseModel] | None = None
+
+
+AdditionalMetadata = dict[str, str]

--- a/hatchet_sdk/v2/callable.py
+++ b/hatchet_sdk/v2/callable.py
@@ -26,7 +26,7 @@ from hatchet_sdk.contracts.workflows_pb2 import (  # type: ignore[attr-defined]
 from hatchet_sdk.labels import DesiredWorkerLabel
 from hatchet_sdk.logger import logger
 from hatchet_sdk.rate_limit import RateLimit
-from hatchet_sdk.utils.types import Input
+from hatchet_sdk.utils.types import JSONSerializableDict
 from hatchet_sdk.v2.concurrency import ConcurrencyFunction
 from hatchet_sdk.workflow_run import RunRef
 
@@ -177,7 +177,7 @@ class DurableContext(Context):
     def run(
         self,
         function: str | Callable[[Context], Any],
-        input: Input = {},
+        input: JSONSerializableDict = {},
         key: str | None = None,
         options: ChildTriggerWorkflowOptions | None = None,
     ) -> "RunRef[T]":

--- a/hatchet_sdk/v2/callable.py
+++ b/hatchet_sdk/v2/callable.py
@@ -26,6 +26,7 @@ from hatchet_sdk.contracts.workflows_pb2 import (  # type: ignore[attr-defined]
 from hatchet_sdk.labels import DesiredWorkerLabel
 from hatchet_sdk.logger import logger
 from hatchet_sdk.rate_limit import RateLimit
+from hatchet_sdk.utils.types import Input
 from hatchet_sdk.v2.concurrency import ConcurrencyFunction
 from hatchet_sdk.workflow_run import RunRef
 
@@ -176,7 +177,7 @@ class DurableContext(Context):
     def run(
         self,
         function: str | Callable[[Context], Any],
-        input: dict[Any, Any] = {},
+        input: Input = {},
         key: str | None = None,
         options: ChildTriggerWorkflowOptions | None = None,
     ) -> "RunRef[T]":

--- a/hatchet_sdk/workflow_run.py
+++ b/hatchet_sdk/workflow_run.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Coroutine, Generic, Optional, TypedDict, TypeVar
+from typing import Any, Coroutine, Generic, TypeVar
 
 from hatchet_sdk.clients.run_event_listener import (
     RunEventListener,

--- a/poetry.lock
+++ b/poetry.lock
@@ -581,12 +581,27 @@ protobuf = ">=3.20.2,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4
 grpc = ["grpcio (>=1.44.0,<2.0.0.dev0)"]
 
 [[package]]
+name = "grpc-stubs"
+version = "1.53.0.5"
+description = "Mypy stubs for gRPC"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "grpc-stubs-1.53.0.5.tar.gz", hash = "sha256:3e1b642775cbc3e0c6332cfcedfccb022176db87e518757bef3a1241397be406"},
+    {file = "grpc_stubs-1.53.0.5-py3-none-any.whl", hash = "sha256:04183fb65a1b166a1febb9627e3d9647d3926ccc2dfe049fe7b6af243428dbe1"},
+]
+
+[package.dependencies]
+grpcio = "*"
+
+[[package]]
 name = "grpcio"
 version = "1.69.0"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "grpcio-1.69.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:2060ca95a8db295ae828d0fc1c7f38fb26ccd5edf9aa51a0f44251f5da332e97"},
     {file = "grpcio-1.69.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:2e52e107261fd8fa8fa457fe44bfadb904ae869d87c1280bf60f93ecd3e79278"},
@@ -2082,4 +2097,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "a51a43e75624789a2044790c6543dacf55f3b8ce2140c9dda1d1300d643df877"
+content-hash = "59a1e9a4aafe7da78bfd9b85af64531167192e56dd0a46dc4c2e40e147cad40d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ prometheus-client = "^0.21.1"
 pytest = "^8.2.2"
 pytest-asyncio = "^0.23.8"
 psutil = "^6.0.0"
+grpc-stubs = "^1.53.0.5"
 
 [tool.poetry.group.lint.dependencies]
 mypy = "^1.14.0"
@@ -98,7 +99,8 @@ files = [
   "hatchet_sdk/context/worker_context.py",
   "hatchet_sdk/clients/dispatcher/dispatcher.py",
   "hatchet_sdk/loader.py",
-  "hatchet_sdk/token.py"
+  "hatchet_sdk/token.py",
+  "hatchet_sdk/clients/admin.py",
 ]
 follow_imports = "silent"
 disable_error_code = ["unused-coroutine"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ files = [
   "hatchet_sdk/loader.py",
   "hatchet_sdk/token.py",
   "hatchet_sdk/clients/admin.py",
+  "hatchet_sdk/clients/events.py",
 ]
 follow_imports = "silent"
 disable_error_code = ["unused-coroutine"]


### PR DESCRIPTION
Removing our uses of typed dicts in favor of Pydantic models to allow for better type checking throughout the codebase. Also got rid of all of the downstream indexing of dictionaries with the `map["key"]` syntax in favor of `obj.key` now. Also improved a lot of the types / defaults for things e.g. going from `foo: dict[str, str] | None = None` to `foo: dict[str, str] = {}` so that we never need to check for a null value when accessing `foo`.

Once this is in I'm going to rewrite the workflow, step, and function implementations mostly from scratch, but trying to be more incremental for some of the internals