### PR TITLE
Feat: V2 Workflows and Steps

### DIFF
--- a/examples/simple/worker.py
+++ b/examples/simple/worker.py
@@ -1,14 +1,14 @@
 from dotenv import load_dotenv
 
 from hatchet_sdk import Context
-from hatchet_sdk.v2 import BaseWorkflowImpl, Hatchet
+from hatchet_sdk.v2 import BaseWorkflow, Hatchet
 
 load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
 
-class MyWorkflow(BaseWorkflowImpl):
+class MyWorkflow(BaseWorkflow):
     @hatchet.step(timeout="11s", retries=3)
     def step1(self, context: Context) -> dict[str, str]:
         print("executed step1")

--- a/examples/simple/worker.py
+++ b/examples/simple/worker.py
@@ -1,9 +1,9 @@
 import time
 
+from dotenv import load_dotenv
+
 from hatchet_sdk import Context
 from hatchet_sdk.v2 import Hatchet, Workflow, WorkflowConfig
-
-from dotenv import load_dotenv
 
 load_dotenv()
 

--- a/examples/simple/worker.py
+++ b/examples/simple/worker.py
@@ -11,7 +11,6 @@ from hatchet_sdk.v2 import Hatchet, Workflow, WorkflowConfig
 # print(os.environ)
 
 
-
 hatchet = Hatchet(debug=True)
 
 

--- a/examples/simple/worker.py
+++ b/examples/simple/worker.py
@@ -1,30 +1,36 @@
 import time
 
-from dotenv import load_dotenv
+from hatchet_sdk import Context
+from hatchet_sdk.v2 import Hatchet, Workflow, WorkflowConfig
 
-from hatchet_sdk import Context, Hatchet
+# from dotenv import load_dotenv
+# load_dotenv()
 
-load_dotenv()
+# import os
+
+# print(os.environ)
+
+
 
 hatchet = Hatchet(debug=True)
 
 
-@hatchet.workflow(on_events=["user:create"])
-class MyWorkflow:
+class MyWorkflow(Workflow):
+    config = WorkflowConfig(name="foobar", on_events=["user:create"])
+
     @hatchet.step(timeout="11s", retries=3)
     def step1(self, context: Context) -> dict[str, str]:
         print("executed step1")
-        time.sleep(10)
-        # raise Exception("test")
         return {
             "step1": "step1",
         }
 
 
 def main() -> None:
-    workflow = MyWorkflow()
+    wf = MyWorkflow()
+
     worker = hatchet.worker("test-worker", max_runs=1)
-    worker.register_workflow(workflow)
+    worker.register_workflow(wf)
     worker.start()
 
 

--- a/examples/simple/worker.py
+++ b/examples/simple/worker.py
@@ -3,13 +3,9 @@ import time
 from hatchet_sdk import Context
 from hatchet_sdk.v2 import Hatchet, Workflow, WorkflowConfig
 
-# from dotenv import load_dotenv
-# load_dotenv()
+from dotenv import load_dotenv
 
-# import os
-
-# print(os.environ)
-
+load_dotenv()
 
 hatchet = Hatchet(debug=True)
 

--- a/examples/simple/worker.py
+++ b/examples/simple/worker.py
@@ -1,17 +1,18 @@
-import time
-
 from dotenv import load_dotenv
 
 from hatchet_sdk import Context
-from hatchet_sdk.v2 import Hatchet, Workflow, WorkflowConfig
+from hatchet_sdk.v2 import BaseWorkflowImpl, Hatchet
 
 load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
 
-class MyWorkflow(Workflow):
-    config = WorkflowConfig(name="foobar", on_events=["user:create"])
+class MyWorkflow(BaseWorkflowImpl):
+    declaration = hatchet.declare_workflow(
+        name="foobar",
+        on_events=["user:create"],
+    )
 
     @hatchet.step(timeout="11s", retries=3)
     def step1(self, context: Context) -> dict[str, str]:

--- a/examples/simple/worker.py
+++ b/examples/simple/worker.py
@@ -9,11 +9,6 @@ hatchet = Hatchet(debug=True)
 
 
 class MyWorkflow(BaseWorkflowImpl):
-    declaration = hatchet.declare_workflow(
-        name="foobar",
-        on_events=["user:create"],
-    )
-
     @hatchet.step(timeout="11s", retries=3)
     def step1(self, context: Context) -> dict[str, str]:
         print("executed step1")

--- a/examples/v2/trigger.py
+++ b/examples/v2/trigger.py
@@ -1,0 +1,11 @@
+from examples.v2.workflows import ExampleWorkflowInput, example_workflow
+
+
+def main() -> None:
+    example_workflow.run(
+        input=ExampleWorkflowInput(message="Hello, world!"),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/v2/worker.py
+++ b/examples/v2/worker.py
@@ -1,0 +1,25 @@
+from examples.v2.workflows import example_workflow, hatchet
+from hatchet_sdk import Context
+from hatchet_sdk.v2 import BaseWorkflowImpl
+
+
+class ExampleV2Workflow(BaseWorkflowImpl):
+    config = example_workflow.config
+
+    @hatchet.step(timeout="11s", retries=3)
+    def step1(self, context: Context) -> None:
+        input = example_workflow.workflow_input(context)
+
+        print(input.message)
+
+        return None
+
+
+def main() -> None:
+    worker = hatchet.worker("test-worker", max_runs=1)
+    worker.register_workflow(ExampleV2Workflow())
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/v2/worker.py
+++ b/examples/v2/worker.py
@@ -1,9 +1,9 @@
 from examples.v2.workflows import example_workflow, hatchet
 from hatchet_sdk import Context
-from hatchet_sdk.v2 import BaseWorkflowImpl
+from hatchet_sdk.v2 import BaseWorkflow
 
 
-class ExampleV2Workflow(BaseWorkflowImpl):
+class ExampleV2Workflow(BaseWorkflow):
     config = example_workflow.config
 
     @hatchet.step(timeout="11s", retries=3)

--- a/examples/v2/workflows.py
+++ b/examples/v2/workflows.py
@@ -1,0 +1,20 @@
+from dotenv import load_dotenv
+from pydantic import BaseModel
+
+from hatchet_sdk.v2 import Hatchet
+
+load_dotenv()
+
+hatchet = Hatchet(debug=True)
+
+
+class ExampleWorkflowInput(BaseModel):
+    message: str
+
+
+example_workflow = hatchet.declare_workflow(
+    name="example-workflow",
+    on_events=["example-event"],
+    timeout="10m",
+    input_validator=ExampleWorkflowInput,
+)

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -91,6 +91,8 @@ class AdminClientBase:
             payload_data = json.dumps(input)
             _options = options.model_dump()
 
+            _options.pop("namespace")
+
             try:
                 _options["additional_metadata"] = json.dumps(
                     options.additional_metadata

--- a/hatchet_sdk/v2.py
+++ b/hatchet_sdk/v2.py
@@ -80,11 +80,13 @@ class Step:
         parents: list[str] = [],
         retries: int = 0,
         rate_limits: list[CreateStepRateLimit] = [],
-        desired_worker_labels: dict[str, DesiredWorkerLabel] = {},
+        desired_worker_labels: dict[str, DesiredWorkerLabels] = {},
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
     ) -> None:
         self.fn = fn
+        self.is_async_function = bool(asyncio.iscoroutinefunction(fn))
+
         self.type = type
         self.timeout = timeout
         self.name = name
@@ -223,7 +225,7 @@ class Workflow:
                 parents=[x for x in step.parents],
                 retries=step.retries,
                 rate_limits=step.rate_limits,
-                worker_labels=step.desired_worker_labels,  # type: ignore[arg-type]
+                worker_labels=step.desired_worker_labels,
                 backoff_factor=step.backoff_factor,
                 backoff_max_seconds=step.backoff_max_seconds,
             )

--- a/hatchet_sdk/v2.py
+++ b/hatchet_sdk/v2.py
@@ -1,0 +1,307 @@
+import asyncio
+import logging
+from typing import Any, Callable, Optional, ParamSpec, Type, TypeVar, Union
+
+from pydantic import BaseModel
+from typing_extensions import deprecated
+
+from hatchet_sdk.clients.rest_client import RestApi
+from hatchet_sdk.context.context import Context
+from hatchet_sdk.contracts.workflows_pb2 import (
+    ConcurrencyLimitStrategy,
+    CreateStepRateLimit,
+    DesiredWorkerLabels,
+    StickyStrategy,
+    WorkerLabelComparator,
+)
+from hatchet_sdk.features.cron import CronClient
+from hatchet_sdk.features.scheduled import ScheduledClient
+from hatchet_sdk.labels import DesiredWorkerLabel
+from hatchet_sdk.loader import ClientConfig
+from hatchet_sdk.rate_limit import RateLimit
+
+from .client import Client, new_client, new_client_raw
+from .clients.admin import AdminClient
+from .clients.dispatcher.dispatcher import DispatcherClient
+from .clients.events import EventClient
+from .clients.run_event_listener import RunEventListenerClient
+from .logger import logger
+from .worker.worker import Worker
+from .workflow import (
+    ConcurrencyExpression,
+    WorkflowInterface,
+    WorkflowMeta,
+    WorkflowStepProtocol,
+)
+
+T = TypeVar("T", bound=BaseModel)
+R = TypeVar("R")
+P = ParamSpec("P")
+
+TWorkflow = TypeVar("TWorkflow", bound=object)
+
+
+def workflow(
+    name: str = "",
+    on_events: list[str] | None = None,
+    on_crons: list[str] | None = None,
+    version: str = "",
+    timeout: str = "60m",
+    schedule_timeout: str = "5m",
+    sticky: Union[StickyStrategy, None] = None,
+    default_priority: int | None = None,
+    concurrency: ConcurrencyExpression | None = None,
+    input_validator: Type[T] | None = None,
+) -> Callable[[Type[TWorkflow]], WorkflowMeta]:
+    on_events = on_events or []
+    on_crons = on_crons or []
+
+    def inner(cls: Type[TWorkflow]) -> WorkflowMeta:
+        nonlocal name
+        name = name or str(cls.__name__)
+
+        setattr(cls, "on_events", on_events)
+        setattr(cls, "on_crons", on_crons)
+        setattr(cls, "name", name)
+        setattr(cls, "version", version)
+        setattr(cls, "timeout", timeout)
+        setattr(cls, "schedule_timeout", schedule_timeout)
+        setattr(cls, "sticky", sticky)
+        setattr(cls, "default_priority", default_priority)
+        setattr(cls, "concurrency_expression", concurrency)
+
+        # Define a new class with the same name and bases as the original, but
+        # with WorkflowMeta as its metaclass
+
+        ## TODO: Figure out how to type this metaclass correctly
+        setattr(cls, "input_validator", input_validator)
+
+        return WorkflowMeta(name, cls.__bases__, dict(cls.__dict__))
+
+    return inner
+
+
+def step(
+    name: str = "",
+    timeout: str = "",
+    parents: list[str] | None = None,
+    retries: int = 0,
+    rate_limits: list[RateLimit] | None = None,
+    desired_worker_labels: dict[str, DesiredWorkerLabel] = {},
+    backoff_factor: float | None = None,
+    backoff_max_seconds: int | None = None,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    parents = parents or []
+
+    def inner(func: Callable[P, R]) -> Callable[P, R]:
+        limits = None
+        if rate_limits:
+            limits = [rate_limit._req for rate_limit in rate_limits or []]
+
+        setattr(func, "_step_name", name.lower() or str(func.__name__).lower())
+        setattr(func, "_step_parents", parents)
+        setattr(func, "_step_timeout", timeout)
+        setattr(func, "_step_retries", retries)
+        setattr(func, "_step_rate_limits", limits)
+        setattr(func, "_step_backoff_factor", backoff_factor)
+        setattr(func, "_step_backoff_max_seconds", backoff_max_seconds)
+
+        def create_label(d: DesiredWorkerLabel) -> DesiredWorkerLabels:
+            value = d.value
+            return DesiredWorkerLabels(
+                strValue=value if not isinstance(value, int) else None,
+                intValue=value if isinstance(value, int) else None,
+                required=d.required,
+                weight=d.weight,
+                comparator=d.comparator,  # type: ignore[arg-type]
+            )
+
+        setattr(
+            func,
+            "_step_desired_worker_labels",
+            {key: create_label(d) for key, d in desired_worker_labels.items()},
+        )
+
+        return func
+
+    return inner
+
+
+def on_failure_step(
+    name: str = "",
+    timeout: str = "",
+    retries: int = 0,
+    rate_limits: list[RateLimit] | None = None,
+    backoff_factor: float | None = None,
+    backoff_max_seconds: int | None = None,
+) -> Callable[..., Any]:
+    def inner(func: Callable[[Context], Any]) -> Callable[[Context], Any]:
+        limits = None
+        if rate_limits:
+            limits = [
+                CreateStepRateLimit(key=rate_limit.static_key, units=rate_limit.units)  # type: ignore[arg-type]
+                for rate_limit in rate_limits or []
+            ]
+
+        setattr(
+            func, "_on_failure_step_name", name.lower() or str(func.__name__).lower()
+        )
+        setattr(func, "_on_failure_step_timeout", timeout)
+        setattr(func, "_on_failure_step_retries", retries)
+        setattr(func, "_on_failure_step_rate_limits", limits)
+        setattr(func, "_on_failure_step_backoff_factor", backoff_factor)
+        setattr(func, "_on_failure_step_backoff_max_seconds", backoff_max_seconds)
+
+        return func
+
+    return inner
+
+
+def concurrency(
+    name: str = "",
+    max_runs: int = 1,
+    limit_strategy: ConcurrencyLimitStrategy = ConcurrencyLimitStrategy.CANCEL_IN_PROGRESS,
+) -> Callable[..., Any]:
+    def inner(func: Callable[[Context], Any]) -> Callable[[Context], Any]:
+        setattr(
+            func,
+            "_concurrency_fn_name",
+            name.lower() or str(func.__name__).lower(),
+        )
+        setattr(func, "_concurrency_max_runs", max_runs)
+        setattr(func, "_concurrency_limit_strategy", limit_strategy)
+
+        return func
+
+    return inner
+
+
+class HatchetRest:
+    """
+    Main client for interacting with the Hatchet API.
+
+    This class provides access to various client interfaces and utility methods
+    for working with Hatchet via the REST API,
+
+    Attributes:
+        rest (RestApi): Interface for REST API operations.
+    """
+
+    def __init__(self, config: ClientConfig = ClientConfig()):
+        self.rest = RestApi(config.server_url, config.token, config.tenant_id)
+
+
+class Hatchet:
+    """
+    Main client for interacting with the Hatchet SDK.
+
+    This class provides access to various client interfaces and utility methods
+    for working with Hatchet workers, workflows, and steps.
+
+    Attributes:
+        cron (CronClient): Interface for cron trigger operations.
+
+        admin (AdminClient): Interface for administrative operations.
+        dispatcher (DispatcherClient): Interface for dispatching operations.
+        event (EventClient): Interface for event-related operations.
+        rest (RestApi): Interface for REST API operations.
+    """
+
+    _client: Client
+    cron: CronClient
+    scheduled: ScheduledClient
+
+    @classmethod
+    def from_environment(
+        cls, defaults: ClientConfig = ClientConfig(), **kwargs: Any
+    ) -> "Hatchet":
+        return cls(client=new_client(defaults), **kwargs)
+
+    @classmethod
+    def from_config(cls, config: ClientConfig, **kwargs: Any) -> "Hatchet":
+        return cls(client=new_client_raw(config), **kwargs)
+
+    def __init__(
+        self,
+        debug: bool = False,
+        client: Optional[Client] = None,
+        config: ClientConfig = ClientConfig(),
+    ):
+        """
+        Initialize a new Hatchet instance.
+
+        Args:
+            debug (bool, optional): Enable debug logging. Defaults to False.
+            client (Optional[Client], optional): A pre-configured Client instance. Defaults to None.
+            config (ClientConfig, optional): Configuration for creating a new Client. Defaults to ClientConfig().
+        """
+        if client is not None:
+            self._client = client
+        else:
+            self._client = new_client(config, debug)
+
+        if debug:
+            logger.setLevel(logging.DEBUG)
+
+        self.cron = CronClient(self._client)
+        self.scheduled = ScheduledClient(self._client)
+
+    @property
+    @deprecated(
+        "Direct access to client is deprecated and will be removed in a future version. Use specific client properties (Hatchet.admin, Hatchet.dispatcher, Hatchet.event, Hatchet.rest) instead. [0.32.0]",
+    )
+    def client(self) -> Client:
+        return self._client
+
+    @property
+    def admin(self) -> AdminClient:
+        return self._client.admin
+
+    @property
+    def dispatcher(self) -> DispatcherClient:
+        return self._client.dispatcher
+
+    @property
+    def event(self) -> EventClient:
+        return self._client.event
+
+    @property
+    def rest(self) -> RestApi:
+        return self._client.rest
+
+    @property
+    def listener(self) -> RunEventListenerClient:
+        return self._client.listener
+
+    @property
+    def config(self) -> ClientConfig:
+        return self._client.config
+
+    @property
+    def tenant_id(self) -> str:
+        return self._client.config.tenant_id
+
+    concurrency = staticmethod(concurrency)
+
+    workflow = staticmethod(workflow)
+
+    step = staticmethod(step)
+
+    on_failure_step = staticmethod(on_failure_step)
+
+    def worker(
+        self, name: str, max_runs: int | None = None, labels: dict[str, str | int] = {}
+    ) -> Worker:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        return Worker(
+            name=name,
+            max_runs=max_runs,
+            labels=labels,
+            config=self._client.config,
+            debug=self._client.debug,
+            owned_loop=loop is None,
+        )

--- a/hatchet_sdk/v2/__init__.py
+++ b/hatchet_sdk/v2/__init__.py
@@ -1,3 +1,3 @@
 from .hatchet import Hatchet as Hatchet
-from .workflows import Workflow as Workflow
+from .workflows import BaseWorkflowImpl as BaseWorkflowImpl
 from .workflows import WorkflowConfig as WorkflowConfig

--- a/hatchet_sdk/v2/__init__.py
+++ b/hatchet_sdk/v2/__init__.py
@@ -1,0 +1,3 @@
+from .hatchet import Hatchet as Hatchet
+from .workflows import Workflow as Workflow
+from .workflows import WorkflowConfig as WorkflowConfig

--- a/hatchet_sdk/v2/__init__.py
+++ b/hatchet_sdk/v2/__init__.py
@@ -1,3 +1,3 @@
 from .hatchet import Hatchet as Hatchet
-from .workflows import BaseWorkflowImpl as BaseWorkflowImpl
+from .workflows import BaseWorkflow as BaseWorkflow
 from .workflows import WorkflowConfig as WorkflowConfig

--- a/hatchet_sdk/v2/hatchet.py
+++ b/hatchet_sdk/v2/hatchet.py
@@ -1,0 +1,176 @@
+import asyncio
+import inspect
+import logging
+from enum import Enum
+from functools import partial
+from typing import Any, Callable, Optional, ParamSpec, Type, TypeVar, Union
+
+from pydantic import BaseModel, ConfigDict
+from typing_extensions import deprecated
+
+from hatchet_sdk.clients.rest_client import RestApi
+from hatchet_sdk.context.context import Context
+from hatchet_sdk.contracts.workflows_pb2 import (
+    ConcurrencyLimitStrategy,
+    CreateStepRateLimit,
+    CreateWorkflowJobOpts,
+    CreateWorkflowStepOpts,
+    CreateWorkflowVersionOpts,
+    DesiredWorkerLabels,
+    StickyStrategy,
+    WorkerLabelComparator,
+    WorkflowConcurrencyOpts,
+    WorkflowKind,
+)
+from hatchet_sdk.features.cron import CronClient
+from hatchet_sdk.features.scheduled import ScheduledClient
+from hatchet_sdk.labels import DesiredWorkerLabel
+from hatchet_sdk.loader import ClientConfig
+from hatchet_sdk.rate_limit import RateLimit
+from hatchet_sdk.v2.workflows import (
+    Step,
+    StepType,
+    Workflow,
+    WorkflowConfig,
+    step_factory,
+)
+
+from ..client import Client, new_client, new_client_raw
+from ..clients.admin import AdminClient
+from ..clients.dispatcher.dispatcher import DispatcherClient
+from ..clients.events import EventClient
+from ..clients.run_event_listener import RunEventListenerClient
+from ..logger import logger
+from ..worker.worker import Worker
+from ..workflow import (
+    ConcurrencyExpression,
+    WorkflowInterface,
+    WorkflowMeta,
+    WorkflowStepProtocol,
+)
+
+
+class HatchetRest:
+    """
+    Main client for interacting with the Hatchet API.
+
+    This class provides access to various client interfaces and utility methods
+    for working with Hatchet via the REST API,
+
+    Attributes:
+        rest (RestApi): Interface for REST API operations.
+    """
+
+    def __init__(self, config: ClientConfig = ClientConfig()):
+        self.rest = RestApi(config.server_url, config.token, config.tenant_id)
+
+
+class Hatchet:
+    """
+    Main client for interacting with the Hatchet SDK.
+
+    This class provides access to various client interfaces and utility methods
+    for working with Hatchet workers, workflows, and steps.
+
+    Attributes:
+        cron (CronClient): Interface for cron trigger operations.
+
+        admin (AdminClient): Interface for administrative operations.
+        dispatcher (DispatcherClient): Interface for dispatching operations.
+        event (EventClient): Interface for event-related operations.
+        rest (RestApi): Interface for REST API operations.
+    """
+
+    _client: Client
+    cron: CronClient
+    scheduled: ScheduledClient
+
+    @classmethod
+    def from_environment(
+        cls, defaults: ClientConfig = ClientConfig(), **kwargs: Any
+    ) -> "Hatchet":
+        return cls(client=new_client(defaults), **kwargs)
+
+    @classmethod
+    def from_config(cls, config: ClientConfig, **kwargs: Any) -> "Hatchet":
+        return cls(client=new_client_raw(config), **kwargs)
+
+    def __init__(
+        self,
+        debug: bool = False,
+        client: Optional[Client] = None,
+        config: ClientConfig = ClientConfig(),
+    ):
+        """
+        Initialize a new Hatchet instance.
+
+        Args:
+            debug (bool, optional): Enable debug logging. Defaults to False.
+            client (Optional[Client], optional): A pre-configured Client instance. Defaults to None.
+            config (ClientConfig, optional): Configuration for creating a new Client. Defaults to ClientConfig().
+        """
+        if client is not None:
+            self._client = client
+        else:
+            self._client = new_client(config, debug)
+
+        if debug:
+            logger.setLevel(logging.DEBUG)
+
+        self.cron = CronClient(self._client)
+        self.scheduled = ScheduledClient(self._client)
+
+    @property
+    @deprecated(
+        "Direct access to client is deprecated and will be removed in a future version. Use specific client properties (Hatchet.admin, Hatchet.dispatcher, Hatchet.event, Hatchet.rest) instead. [0.32.0]",
+    )
+    def client(self) -> Client:
+        return self._client
+
+    @property
+    def admin(self) -> AdminClient:
+        return self._client.admin
+
+    @property
+    def dispatcher(self) -> DispatcherClient:
+        return self._client.dispatcher
+
+    @property
+    def event(self) -> EventClient:
+        return self._client.event
+
+    @property
+    def rest(self) -> RestApi:
+        return self._client.rest
+
+    @property
+    def listener(self) -> RunEventListenerClient:
+        return self._client.listener
+
+    @property
+    def config(self) -> ClientConfig:
+        return self._client.config
+
+    @property
+    def tenant_id(self) -> str:
+        return self._client.config.tenant_id
+
+    step = staticmethod(step_factory(type=StepType.DEFAULT))
+    on_failure_step = staticmethod(step_factory(type=StepType.ON_FAILURE))
+
+    def worker(
+        self, name: str, max_runs: int | None = None, labels: dict[str, str | int] = {}
+    ) -> Worker:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        return Worker(
+            name=name,
+            max_runs=max_runs,
+            labels=labels,
+            config=self._client.config,
+            debug=self._client.debug,
+            owned_loop=loop is None,
+        )

--- a/hatchet_sdk/v2/hatchet.py
+++ b/hatchet_sdk/v2/hatchet.py
@@ -35,7 +35,6 @@ from hatchet_sdk.labels import DesiredWorkerLabel
 from hatchet_sdk.loader import ClientConfig
 from hatchet_sdk.rate_limit import RateLimit
 from hatchet_sdk.v2.workflows import Step, StepType
-from hatchet_sdk.worker.worker import Worker
 
 from ..client import Client, new_client, new_client_raw
 from ..clients.admin import AdminClient
@@ -44,6 +43,8 @@ from ..clients.events import EventClient
 from ..clients.run_event_listener import RunEventListenerClient
 from ..logger import logger
 
+if TYPE_CHECKING:
+    from hatchet_sdk.worker.worker import Worker
 R = TypeVar("R")
 
 
@@ -206,7 +207,7 @@ class Hatchet:
     ) -> Callable[[Callable[[Any, Context], Any]], Step[R]]:
         def inner(func: Callable[[Any, Context], R]) -> Step[R]:
             return Step(
-                fn=func,  # The Step class will handle the self parameter
+                fn=func,
                 type=StepType.ON_FAILURE,
                 name=name.lower() or str(func.__name__).lower(),
                 timeout=timeout,
@@ -225,7 +226,9 @@ class Hatchet:
 
     def worker(
         self, name: str, max_runs: int | None = None, labels: dict[str, str | int] = {}
-    ) -> Worker:
+    ) -> "Worker":
+        from hatchet_sdk.worker.worker import Worker
+
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:

--- a/hatchet_sdk/v2/hatchet.py
+++ b/hatchet_sdk/v2/hatchet.py
@@ -1,28 +1,24 @@
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
-from typing_extensions import deprecated
-
+from hatchet_sdk.client import Client, new_client, new_client_raw
+from hatchet_sdk.clients.admin import AdminClient
+from hatchet_sdk.clients.dispatcher.dispatcher import DispatcherClient
+from hatchet_sdk.clients.events import EventClient
 from hatchet_sdk.clients.rest_client import RestApi
+from hatchet_sdk.clients.run_event_listener import RunEventListenerClient
 from hatchet_sdk.context.context import Context
 from hatchet_sdk.contracts.workflows_pb2 import DesiredWorkerLabels
 from hatchet_sdk.features.cron import CronClient
 from hatchet_sdk.features.scheduled import ScheduledClient
 from hatchet_sdk.labels import DesiredWorkerLabel
 from hatchet_sdk.loader import ClientConfig
+from hatchet_sdk.logger import logger
 from hatchet_sdk.rate_limit import RateLimit
 from hatchet_sdk.v2.workflows import Step, StepType
+from hatchet_sdk.worker.worker import Worker
 
-from ..client import Client, new_client, new_client_raw
-from ..clients.admin import AdminClient
-from ..clients.dispatcher.dispatcher import DispatcherClient
-from ..clients.events import EventClient
-from ..clients.run_event_listener import RunEventListenerClient
-from ..logger import logger
-
-if TYPE_CHECKING:
-    from hatchet_sdk.worker.worker import Worker
 R = TypeVar("R")
 
 
@@ -91,13 +87,6 @@ class Hatchet:
 
         self.cron = CronClient(self._client)
         self.scheduled = ScheduledClient(self._client)
-
-    @property
-    @deprecated(
-        "Direct access to client is deprecated and will be removed in a future version. Use specific client properties (Hatchet.admin, Hatchet.dispatcher, Hatchet.event, Hatchet.rest) instead. [0.32.0]",
-    )
-    def client(self) -> Client:
-        return self._client
 
     @property
     def admin(self) -> AdminClient:
@@ -190,8 +179,6 @@ class Hatchet:
     def worker(
         self, name: str, max_runs: int | None = None, labels: dict[str, str | int] = {}
     ) -> "Worker":
-        from hatchet_sdk.worker.worker import Worker
-
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:

--- a/hatchet_sdk/v2/hatchet.py
+++ b/hatchet_sdk/v2/hatchet.py
@@ -1,34 +1,12 @@
 import asyncio
 import logging
-from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Generic,
-    Optional,
-    ParamSpec,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
-from pydantic import BaseModel, ConfigDict
 from typing_extensions import deprecated
 
 from hatchet_sdk.clients.rest_client import RestApi
 from hatchet_sdk.context.context import Context
-from hatchet_sdk.contracts.workflows_pb2 import (
-    ConcurrencyLimitStrategy,
-    CreateStepRateLimit,
-    CreateWorkflowJobOpts,
-    CreateWorkflowStepOpts,
-    CreateWorkflowVersionOpts,
-    DesiredWorkerLabels,
-    StickyStrategy,
-    WorkflowConcurrencyOpts,
-    WorkflowKind,
-)
+from hatchet_sdk.contracts.workflows_pb2 import DesiredWorkerLabels
 from hatchet_sdk.features.cron import CronClient
 from hatchet_sdk.features.scheduled import ScheduledClient
 from hatchet_sdk.labels import DesiredWorkerLabel
@@ -46,21 +24,6 @@ from ..logger import logger
 if TYPE_CHECKING:
     from hatchet_sdk.worker.worker import Worker
 R = TypeVar("R")
-
-
-class HatchetRest:
-    """
-    Main client for interacting with the Hatchet API.
-
-    This class provides access to various client interfaces and utility methods
-    for working with Hatchet via the REST API,
-
-    Attributes:
-        rest (RestApi): Interface for REST API operations.
-    """
-
-    def __init__(self, config: ClientConfig = ClientConfig()):
-        self.rest = RestApi(config.server_url, config.token, config.tenant_id)
 
 
 def transform_desired_worker_label(d: DesiredWorkerLabel) -> DesiredWorkerLabels:

--- a/hatchet_sdk/v2/hatchet.py
+++ b/hatchet_sdk/v2/hatchet.py
@@ -1,39 +1,15 @@
 import asyncio
-import inspect
 import logging
-from enum import Enum
-from functools import partial
-from typing import Any, Callable, Optional, ParamSpec, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional
 
-from pydantic import BaseModel, ConfigDict
 from typing_extensions import deprecated
 
 from hatchet_sdk.clients.rest_client import RestApi
-from hatchet_sdk.context.context import Context
-from hatchet_sdk.contracts.workflows_pb2 import (
-    ConcurrencyLimitStrategy,
-    CreateStepRateLimit,
-    CreateWorkflowJobOpts,
-    CreateWorkflowStepOpts,
-    CreateWorkflowVersionOpts,
-    DesiredWorkerLabels,
-    StickyStrategy,
-    WorkerLabelComparator,
-    WorkflowConcurrencyOpts,
-    WorkflowKind,
-)
 from hatchet_sdk.features.cron import CronClient
 from hatchet_sdk.features.scheduled import ScheduledClient
-from hatchet_sdk.labels import DesiredWorkerLabel
 from hatchet_sdk.loader import ClientConfig
-from hatchet_sdk.rate_limit import RateLimit
-from hatchet_sdk.v2.workflows import (
-    Step,
-    StepType,
-    Workflow,
-    WorkflowConfig,
-    step_factory,
-)
+from hatchet_sdk.v2.workflows import StepType, step_factory
+from hatchet_sdk.worker import Worker
 
 from ..client import Client, new_client, new_client_raw
 from ..clients.admin import AdminClient
@@ -41,13 +17,6 @@ from ..clients.dispatcher.dispatcher import DispatcherClient
 from ..clients.events import EventClient
 from ..clients.run_event_listener import RunEventListenerClient
 from ..logger import logger
-from ..worker.worker import Worker
-from ..workflow import (
-    ConcurrencyExpression,
-    WorkflowInterface,
-    WorkflowMeta,
-    WorkflowStepProtocol,
-)
 
 
 class HatchetRest:

--- a/hatchet_sdk/v2/hatchet.py
+++ b/hatchet_sdk/v2/hatchet.py
@@ -1,21 +1,6 @@
 import asyncio
 import logging
-from enum import Enum
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Generic,
-    Optional,
-    ParamSpec,
-    Type,
-    TypeGuard,
-    TypeVar,
-    Union,
-    cast,
-)
-
-from pydantic import BaseModel, ConfigDict
+from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar, cast
 
 from hatchet_sdk.client import Client, new_client, new_client_raw
 from hatchet_sdk.clients.admin import AdminClient
@@ -41,7 +26,9 @@ from hatchet_sdk.v2.workflows import (
     WorkflowConfig,
     WorkflowDeclaration,
 )
-from hatchet_sdk.worker.worker import Worker
+
+if TYPE_CHECKING:
+    from hatchet_sdk.worker.worker import Worker
 
 R = TypeVar("R")
 
@@ -203,6 +190,8 @@ class Hatchet:
     def worker(
         self, name: str, max_runs: int | None = None, labels: dict[str, str | int] = {}
     ) -> "Worker":
+        from hatchet_sdk.worker.worker import Worker
+
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:

--- a/hatchet_sdk/v2/workflows.py
+++ b/hatchet_sdk/v2/workflows.py
@@ -178,6 +178,9 @@ class WorkflowDeclaration(Generic[TWorkflowInput]):
             workflow_name=self.config.name, input=input.model_dump() if input else {}
         )
 
+    def workflow_input(self, ctx: Context) -> TWorkflowInput:
+        return cast(TWorkflowInput, ctx.workflow_input())
+
 
 class BaseWorkflowImpl:
     """
@@ -186,9 +189,10 @@ class BaseWorkflowImpl:
     Configuration is passed to the workflow implementation via the `config` attribute.
     """
 
-    declaration: WorkflowDeclaration = WorkflowDeclaration(
-        config=WorkflowConfig(), hatchet=None
-    )
+    config: WorkflowConfig = WorkflowConfig()
+
+    def __init__(self) -> None:
+        self.config.name = self.config.name or str(self.__class__.__name__)
 
     def get_service_name(self, namespace: str) -> str:
         return f"{namespace}{self.config.name.lower()}"
@@ -218,10 +222,6 @@ class BaseWorkflowImpl:
 
     def create_action_name(self, namespace: str, step: Step[Any]) -> str:
         return self.get_service_name(namespace) + ":" + step.name
-
-    def __init__(self) -> None:
-        self.config = self.declaration.config
-        self.config.name = self.config.name or str(self.__class__.__name__)
 
     def get_name(self, namespace: str) -> str:
         return namespace + self.config.name

--- a/hatchet_sdk/v2/workflows.py
+++ b/hatchet_sdk/v2/workflows.py
@@ -116,6 +116,8 @@ class Step(Generic[R]):
         desired_worker_labels: dict[str, DesiredWorkerLabels] = {},
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
+        concurrency__max_runs: int | None = None,
+        concurrency__limit_strategy: ConcurrencyLimitStrategy | None = None,
     ) -> None:
         self.fn = fn
         self.is_async_function = is_async_fn(fn)
@@ -129,8 +131,8 @@ class Step(Generic[R]):
         self.desired_worker_labels = desired_worker_labels
         self.backoff_factor = backoff_factor
         self.backoff_max_seconds = backoff_max_seconds
-        self.concurrency__max_runs = 1
-        self.concurrency__limit_strategy = ConcurrencyLimitStrategy.CANCEL_IN_PROGRESS
+        self.concurrency__max_runs = concurrency__max_runs
+        self.concurrency__limit_strategy = concurrency__limit_strategy
 
     def call(self, ctx: Context) -> R:
         if self.is_async_function:

--- a/hatchet_sdk/v2/workflows.py
+++ b/hatchet_sdk/v2/workflows.py
@@ -146,7 +146,7 @@ class Step(Generic[R]):
 class RegisteredStep(Step[R]):
     def __init__(
         self,
-        workflow: "BaseWorkflowImpl",
+        workflow: "BaseWorkflow",
         step: Step[R],
     ) -> None:
         self.workflow = workflow
@@ -193,7 +193,7 @@ class WorkflowDeclaration(Generic[TWorkflowInput]):
         return cast(TWorkflowInput, ctx.workflow_input())
 
 
-class BaseWorkflowImpl:
+class BaseWorkflow:
     """
     A Hatchet workflow implementation base. This class should be inherited by all workflow implementations.
 

--- a/hatchet_sdk/v2/workflows.py
+++ b/hatchet_sdk/v2/workflows.py
@@ -166,11 +166,14 @@ class Step(Generic[R]):
 
 
 class WorkflowDeclaration(Generic[TWorkflowInput]):
-    def __init__(self, config: WorkflowConfig, hatchet: "Hatchet"):
+    def __init__(self, config: WorkflowConfig, hatchet: Union["Hatchet", None]):
         self.config = config
         self.hatchet = hatchet
 
     def run(self, input: TWorkflowInput | None = None) -> Any:
+        if not self.hatchet:
+            raise ValueError("Hatchet client is not initialized.")
+
         return self.hatchet.admin.run_workflow(
             workflow_name=self.config.name, input=input.model_dump() if input else {}
         )
@@ -183,7 +186,9 @@ class BaseWorkflowImpl:
     Configuration is passed to the workflow implementation via the `config` attribute.
     """
 
-    declaration: WorkflowDeclaration
+    declaration: WorkflowDeclaration = WorkflowDeclaration(
+        config=WorkflowConfig(), hatchet=None
+    )
 
     def get_service_name(self, namespace: str) -> str:
         return f"{namespace}{self.config.name.lower()}"

--- a/hatchet_sdk/v2/workflows.py
+++ b/hatchet_sdk/v2/workflows.py
@@ -143,7 +143,7 @@ class Step(Generic[R]):
         self.concurrency__limit_strategy = concurrency__limit_strategy
 
 
-class RegisteredStep(Step[R]):
+class RegisteredStep(Generic[R]):
     def __init__(
         self,
         workflow: "BaseWorkflow",
@@ -153,27 +153,33 @@ class RegisteredStep(Step[R]):
         self.step = step
 
     def call(self, ctx: Context) -> R:
-        if self.is_async_function:
-            raise TypeError(f"{self.name} is not a sync function. Use `acall` instead.")
+        if self.step.is_async_function:
+            raise TypeError(
+                f"{self.step.name} is not a sync function. Use `acall` instead."
+            )
 
-        sync_fn = self.fn
+        sync_fn = self.step.fn
         if is_sync_fn(sync_fn):
             return sync_fn(self.workflow, ctx)
 
-        raise TypeError(f"{self.name} is not a sync function. Use `acall` instead.")
+        raise TypeError(
+            f"{self.step.name} is not a sync function. Use `acall` instead."
+        )
 
     async def acall(self, ctx: Context) -> R:
-        if not self.is_async_function:
+        if not self.step.is_async_function:
             raise TypeError(
-                f"{self.name} is not an async function. Use `call` instead."
+                f"{self.step.name} is not an async function. Use `call` instead."
             )
 
-        async_fn = self.fn
+        async_fn = self.step.fn
 
         if is_async_fn(async_fn):
             return await async_fn(self.workflow, ctx)
 
-        raise TypeError(f"{self.name} is not an async function. Use `call` instead.")
+        raise TypeError(
+            f"{self.step.name} is not an async function. Use `call` instead."
+        )
 
 
 class WorkflowDeclaration(Generic[TWorkflowInput]):

--- a/hatchet_sdk/worker/runner/run_loop_manager.py
+++ b/hatchet_sdk/worker/runner/run_loop_manager.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from multiprocessing import Queue
-from typing import Callable, Literal, TypeVar
+from typing import TYPE_CHECKING, Callable, Literal, TypeVar
 
 from hatchet_sdk import Context
 from hatchet_sdk.client import Client, new_client_raw
@@ -14,16 +14,20 @@ from hatchet_sdk.worker.action_listener_process import ActionEvent
 from hatchet_sdk.worker.runner.runner import Runner
 from hatchet_sdk.worker.runner.utils.capture_logs import capture_logs
 
+if TYPE_CHECKING:
+    from hatchet_sdk.v2.workflows import Step
+
 STOP_LOOP_TYPE = Literal["STOP_LOOP"]
 STOP_LOOP: STOP_LOOP_TYPE = "STOP_LOOP"
 
 T = TypeVar("T")
+from typing import Any
 
 
 @dataclass
 class WorkerActionRunLoopManager:
     name: str
-    action_registry: dict[str, Callable[[Context], T]]
+    action_registry: dict[str, "Step[Any]"]
     validator_registry: dict[str, WorkflowValidator]
     max_runs: int | None
     config: ClientConfig

--- a/hatchet_sdk/worker/runner/run_loop_manager.py
+++ b/hatchet_sdk/worker/runner/run_loop_manager.py
@@ -15,7 +15,7 @@ from hatchet_sdk.worker.runner.runner import Runner
 from hatchet_sdk.worker.runner.utils.capture_logs import capture_logs
 
 if TYPE_CHECKING:
-    from hatchet_sdk.v2.workflows import RegisteredStep
+    from hatchet_sdk.v2.workflows import Step
 
 STOP_LOOP_TYPE = Literal["STOP_LOOP"]
 STOP_LOOP: STOP_LOOP_TYPE = "STOP_LOOP"
@@ -27,7 +27,7 @@ from typing import Any
 @dataclass
 class WorkerActionRunLoopManager:
     name: str
-    action_registry: dict[str, "RegisteredStep[Any]"]
+    action_registry: dict[str, "Step[Any]"]
     validator_registry: dict[str, WorkflowValidator]
     max_runs: int | None
     config: ClientConfig

--- a/hatchet_sdk/worker/runner/run_loop_manager.py
+++ b/hatchet_sdk/worker/runner/run_loop_manager.py
@@ -15,7 +15,7 @@ from hatchet_sdk.worker.runner.runner import Runner
 from hatchet_sdk.worker.runner.utils.capture_logs import capture_logs
 
 if TYPE_CHECKING:
-    from hatchet_sdk.v2.workflows import Step
+    from hatchet_sdk.v2.workflows import RegisteredStep
 
 STOP_LOOP_TYPE = Literal["STOP_LOOP"]
 STOP_LOOP: STOP_LOOP_TYPE = "STOP_LOOP"
@@ -27,7 +27,7 @@ from typing import Any
 @dataclass
 class WorkerActionRunLoopManager:
     name: str
-    action_registry: dict[str, "Step[Any]"]
+    action_registry: dict[str, "RegisteredStep[Any]"]
     validator_registry: dict[str, WorkflowValidator]
     max_runs: int | None
     config: ClientConfig

--- a/hatchet_sdk/worker/runner/runner.py
+++ b/hatchet_sdk/worker/runner/runner.py
@@ -8,17 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from multiprocessing import Queue
 from threading import Thread, current_thread
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Literal,
-    Type,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, TypeVar, cast
 
 from opentelemetry.trace import StatusCode
 from pydantic import BaseModel

--- a/hatchet_sdk/worker/runner/runner.py
+++ b/hatchet_sdk/worker/runner/runner.py
@@ -225,7 +225,9 @@ class Runner:
         return inner_callback
 
     ## TODO: Stricter type hinting here
-    def thread_action_func(self, context: Context, step: "Step[T]", action: Action) -> T:
+    def thread_action_func(
+        self, context: Context, step: "Step[T]", action: Action
+    ) -> T:
         if action.step_run_id is not None and action.step_run_id != "":
             self.threads[action.step_run_id] = current_thread()
         elif (

--- a/hatchet_sdk/worker/runner/runner.py
+++ b/hatchet_sdk/worker/runner/runner.py
@@ -47,6 +47,8 @@ from hatchet_sdk.utils.types import WorkflowValidator
 from hatchet_sdk.worker.action_listener_process import ActionEvent
 from hatchet_sdk.worker.runner.utils.capture_logs import copy_context_vars, sr, wr
 
+T = TypeVar("T")
+
 if TYPE_CHECKING:
     from hatchet_sdk.v2.workflows import Step
 
@@ -65,7 +67,7 @@ class Runner:
         event_queue: "Queue[Any]",
         max_runs: int | None = None,
         handle_kill: bool = True,
-        action_registry: dict[str, "Step[Any]"] = {},
+        action_registry: dict[str, "Step[T]"] = {},
         validator_registry: dict[str, WorkflowValidator] = {},
         config: ClientConfig = ClientConfig(),
         labels: dict[str, str | int] = {},
@@ -77,7 +79,7 @@ class Runner:
         self.max_runs = max_runs
         self.tasks: dict[str, asyncio.Task[Any]] = {}  # Store run ids and futures
         self.contexts: dict[str, Context] = {}  # Store run ids and contexts
-        self.action_registry: dict[str, "Step[Any]"] = action_registry
+        self.action_registry: dict[str, "Step[T]"] = action_registry
         self.validator_registry = validator_registry
 
         self.event_queue = event_queue
@@ -223,9 +225,7 @@ class Runner:
         return inner_callback
 
     ## TODO: Stricter type hinting here
-    def thread_action_func(
-        self, context: Context, action_func: Callable[..., Any], action: Action
-    ) -> Any:
+    def thread_action_func(self, context: Context, step: Step[T], action: Action) -> T:
         if action.step_run_id is not None and action.step_run_id != "":
             self.threads[action.step_run_id] = current_thread()
         elif (
@@ -234,25 +234,23 @@ class Runner:
         ):
             self.threads[action.get_group_key_run_id] = current_thread()
 
-        return action_func(context)
+        return step.call(context)
 
     ## TODO: Stricter type hinting here
     # We wrap all actions in an async func
     async def async_wrapped_action_func(
         self,
         context: Context,
-        action_func: Callable[..., Any],
+        step: Step[T],
         action: Action,
         run_id: str,
-    ) -> Any:
+    ) -> T:
         wr.set(context.workflow_run_id())
         sr.set(context.step_run_id)
 
         try:
-            if (
-                hasattr(action_func, "is_coroutine") and action_func.is_coroutine
-            ) or asyncio.iscoroutinefunction(action_func):
-                return await action_func(context)
+            if step.is_async_function:
+                return await step.acall(context)
             else:
                 pfunc = functools.partial(
                     # we must copy the context vars to the new thread, as only asyncio natively supports
@@ -261,7 +259,7 @@ class Runner:
                     contextvars.copy_context().items(),
                     self.thread_action_func,
                     context,
-                    action_func,
+                    step,
                     action,
                 )
 

--- a/hatchet_sdk/worker/runner/runner.py
+++ b/hatchet_sdk/worker/runner/runner.py
@@ -40,7 +40,7 @@ from hatchet_sdk.worker.runner.utils.capture_logs import copy_context_vars, sr, 
 T = TypeVar("T")
 
 if TYPE_CHECKING:
-    from hatchet_sdk.v2.workflows import Step
+    from hatchet_sdk.v2.workflows import RegisteredStep
 
 
 class WorkerStatus(Enum):
@@ -57,7 +57,7 @@ class Runner:
         event_queue: "Queue[Any]",
         max_runs: int | None = None,
         handle_kill: bool = True,
-        action_registry: dict[str, "Step[T]"] = {},
+        action_registry: dict[str, "RegisteredStep[T]"] = {},
         validator_registry: dict[str, WorkflowValidator] = {},
         config: ClientConfig = ClientConfig(),
         labels: dict[str, str | int] = {},
@@ -69,7 +69,7 @@ class Runner:
         self.max_runs = max_runs
         self.tasks: dict[str, asyncio.Task[Any]] = {}  # Store run ids and futures
         self.contexts: dict[str, Context] = {}  # Store run ids and contexts
-        self.action_registry: dict[str, "Step[T]"] = action_registry
+        self.action_registry: dict[str, "RegisteredStep[T]"] = action_registry
         self.validator_registry = validator_registry
 
         self.event_queue = event_queue
@@ -216,7 +216,7 @@ class Runner:
 
     ## TODO: Stricter type hinting here
     def thread_action_func(
-        self, context: Context, step: "Step[T]", action: Action
+        self, context: Context, step: "RegisteredStep[T]", action: Action
     ) -> T:
         if action.step_run_id is not None and action.step_run_id != "":
             self.threads[action.step_run_id] = current_thread()
@@ -233,7 +233,7 @@ class Runner:
     async def async_wrapped_action_func(
         self,
         context: Context,
-        step: "Step[T]",
+        step: "RegisteredStep[T]",
         action: Action,
         run_id: str,
     ) -> T:

--- a/hatchet_sdk/worker/runner/runner.py
+++ b/hatchet_sdk/worker/runner/runner.py
@@ -8,7 +8,17 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from multiprocessing import Queue
 from threading import Thread, current_thread
-from typing import Any, Callable, Dict, Literal, Type, TypeVar, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Literal,
+    Type,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from opentelemetry.trace import StatusCode
 from pydantic import BaseModel
@@ -37,6 +47,9 @@ from hatchet_sdk.utils.types import WorkflowValidator
 from hatchet_sdk.worker.action_listener_process import ActionEvent
 from hatchet_sdk.worker.runner.utils.capture_logs import copy_context_vars, sr, wr
 
+if TYPE_CHECKING:
+    from hatchet_sdk.v2.workflows import Step
+
 
 class WorkerStatus(Enum):
     INITIALIZED = 1
@@ -52,7 +65,7 @@ class Runner:
         event_queue: "Queue[Any]",
         max_runs: int | None = None,
         handle_kill: bool = True,
-        action_registry: dict[str, Callable[..., Any]] = {},
+        action_registry: dict[str, "Step[Any]"] = {},
         validator_registry: dict[str, WorkflowValidator] = {},
         config: ClientConfig = ClientConfig(),
         labels: dict[str, str | int] = {},
@@ -64,7 +77,7 @@ class Runner:
         self.max_runs = max_runs
         self.tasks: dict[str, asyncio.Task[Any]] = {}  # Store run ids and futures
         self.contexts: dict[str, Context] = {}  # Store run ids and contexts
-        self.action_registry: dict[str, Callable[..., Any]] = action_registry
+        self.action_registry: dict[str, "Step[Any]"] = action_registry
         self.validator_registry = validator_registry
 
         self.event_queue = event_queue

--- a/hatchet_sdk/worker/runner/runner.py
+++ b/hatchet_sdk/worker/runner/runner.py
@@ -241,7 +241,7 @@ class Runner:
         sr.set(context.step_run_id)
 
         try:
-            if step.is_async_function:
+            if step.step.is_async_function:
                 return await step.acall(context)
             else:
                 pfunc = functools.partial(

--- a/hatchet_sdk/worker/runner/runner.py
+++ b/hatchet_sdk/worker/runner/runner.py
@@ -225,7 +225,7 @@ class Runner:
         return inner_callback
 
     ## TODO: Stricter type hinting here
-    def thread_action_func(self, context: Context, step: Step[T], action: Action) -> T:
+    def thread_action_func(self, context: Context, step: "Step[T]", action: Action) -> T:
         if action.step_run_id is not None and action.step_run_id != "":
             self.threads[action.step_run_id] = current_thread()
         elif (
@@ -241,7 +241,7 @@ class Runner:
     async def async_wrapped_action_func(
         self,
         context: Context,
-        step: Step[T],
+        step: "Step[T]",
         action: Action,
         run_id: str,
     ) -> T:

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -36,7 +36,7 @@ from hatchet_sdk.worker.runner.run_loop_manager import (
 )
 
 if TYPE_CHECKING:
-    from hatchet_sdk.v2 import BaseWorkflowImpl
+    from hatchet_sdk.v2 import BaseWorkflow
 
 T = TypeVar("T")
 
@@ -110,7 +110,7 @@ class Worker:
             logger.error(e)
             sys.exit(1)
 
-    def register_workflow(self, workflow: Union["BaseWorkflowImpl", Any]) -> None:
+    def register_workflow(self, workflow: Union["BaseWorkflow", Any]) -> None:
         namespace = self.client.config.namespace
 
         try:

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -25,7 +25,7 @@ from hatchet_sdk.loader import ClientConfig
 from hatchet_sdk.logger import logger
 from hatchet_sdk.utils.types import WorkflowValidator
 from hatchet_sdk.utils.typing import is_basemodel_subclass
-from hatchet_sdk.v2.workflows import RegisteredStep, StepType
+from hatchet_sdk.v2.workflows import Step, StepType
 from hatchet_sdk.worker.action_listener_process import (
     ActionEvent,
     worker_action_listener_process,
@@ -74,7 +74,7 @@ class Worker:
 
         self.client: Client
 
-        self.action_registry: dict[str, RegisteredStep[Any]] = {}
+        self.action_registry: dict[str, Step[Any]] = {}
         self.validator_registry: dict[str, WorkflowValidator] = {}
 
         self.killing: bool = False
@@ -123,10 +123,10 @@ class Worker:
             sys.exit(1)
 
         for step in workflow.steps:
+            step.workflow = workflow
+
             action_name = workflow.create_action_name(namespace, step)
-            self.action_registry[action_name] = RegisteredStep(
-                workflow=workflow, step=step
-            )
+            self.action_registry[action_name] = step
             return_type = get_type_hints(step.fn).get("return")
 
             self.validator_registry[action_name] = WorkflowValidator(

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -25,7 +25,7 @@ from hatchet_sdk.loader import ClientConfig
 from hatchet_sdk.logger import logger
 from hatchet_sdk.utils.types import WorkflowValidator
 from hatchet_sdk.utils.typing import is_basemodel_subclass
-from hatchet_sdk.v2.workflows import Step, StepType
+from hatchet_sdk.v2.workflows import RegisteredStep, StepType
 from hatchet_sdk.worker.action_listener_process import (
     ActionEvent,
     worker_action_listener_process,
@@ -74,7 +74,7 @@ class Worker:
 
         self.client: Client
 
-        self.action_registry: dict[str, Step[Any]] = {}
+        self.action_registry: dict[str, RegisteredStep[Any]] = {}
         self.validator_registry: dict[str, WorkflowValidator] = {}
 
         self.killing: bool = False
@@ -124,7 +124,9 @@ class Worker:
 
         for step in workflow.steps:
             action_name = workflow.create_action_name(namespace, step)
-            self.action_registry[action_name] = step
+            self.action_registry[action_name] = RegisteredStep(
+                workflow=workflow, step=step
+            )
             return_type = get_type_hints(step.fn).get("return")
 
             self.validator_registry[action_name] = WorkflowValidator(

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -25,6 +25,7 @@ from hatchet_sdk.loader import ClientConfig
 from hatchet_sdk.logger import logger
 from hatchet_sdk.utils.types import WorkflowValidator
 from hatchet_sdk.utils.typing import is_basemodel_subclass
+from hatchet_sdk.v2.workflows import Step, StepType
 from hatchet_sdk.worker.action_listener_process import (
     ActionEvent,
     worker_action_listener_process,
@@ -36,7 +37,6 @@ from hatchet_sdk.worker.runner.run_loop_manager import (
 
 if TYPE_CHECKING:
     from hatchet_sdk.v2 import Workflow
-    from hatchet_sdk.v2.workflows import Step
 
 T = TypeVar("T")
 

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -36,7 +36,7 @@ from hatchet_sdk.worker.runner.run_loop_manager import (
 )
 
 if TYPE_CHECKING:
-    from hatchet_sdk.v2 import Workflow
+    from hatchet_sdk.v2 import BaseWorkflowImpl
 
 T = TypeVar("T")
 
@@ -110,7 +110,7 @@ class Worker:
             logger.error(e)
             sys.exit(1)
 
-    def register_workflow(self, workflow: Union["Workflow", Any]) -> None:
+    def register_workflow(self, workflow: Union["BaseWorkflowImpl", Any]) -> None:
         namespace = self.client.config.namespace
 
         try:

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -123,8 +123,6 @@ class Worker:
             sys.exit(1)
 
         for step in workflow.steps:
-            step.workflow = workflow
-
             action_name = workflow.create_action_name(namespace, step)
             self.action_registry[action_name] = step
             return_type = get_type_hints(step.fn).get("return")

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -113,11 +113,10 @@ class Worker:
             logger.error(e)
             sys.exit(1)
 
-    def register_workflow(self, workflow: TWorkflow) -> None:
-        ## Hack for typing
-        assert isinstance(workflow, WorkflowInterface)
-
+    def register_workflow(self, workflow) -> None:
         namespace = self.client.config.namespace
+
+        print(f"registering workflow: {workflow}", workflow.steps)
 
         try:
             self.client.admin.put_workflow(

--- a/hatchet_sdk/workflow.py
+++ b/hatchet_sdk/workflow.py
@@ -7,7 +7,6 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_type_hints,
     runtime_checkable,
 )
 
@@ -23,7 +22,6 @@ from hatchet_sdk.contracts.workflows_pb2 import (
     WorkflowKind,
 )
 from hatchet_sdk.logger import logger
-from hatchet_sdk.utils.typing import is_basemodel_subclass
 
 
 class WorkflowStepProtocol(Protocol):


### PR DESCRIPTION
### This is a lot, but please read it - I need some feedback in a couple of spots :) 

This PR implements the V2 SDK's definitions of workflows and steps (standalone functions soon to come). There's a lot going on here, sorry about that 😄 

First, some things less related to workflows:

1. There's a new [`Step` class](https://github.com/hatchet-dev/hatchet-python-v2/pull/5/files#diff-d47e8f44822a7b3b74e14d1708686c24404b021a98052ff567786cf715b362b6R113) that's has a generic param (the return type), which implements `call` and `acall` methods and has all the same parameters as the old steps, just as a class as opposed to as a function. This helps type checking a lot - we can know the return type of the step (at least in generic terms) in the other places in the code, can access attributes correctly, and so on.
2. The `Step` is passed around everywhere now, so there's much less of a notion of an "action function". Instead, we just pass the step and figure out how to call it depending on if it's `is_async_function` is `True` or `False`. This is also a dramatic improvement for type checking, e.g. [here](https://github.com/hatchet-dev/hatchet-python-v2/pull/5/files#diff-024202bc49ccf0977187577270aa1be7a781db1a0c17d67a960ccf6630184fb3L214-R220) or [here](https://github.com/hatchet-dev/hatchet-python-v2/pull/5/files#diff-024202bc49ccf0977187577270aa1be7a781db1a0c17d67a960ccf6630184fb3R239)
3. When we go to register a workflow, all we need to do is loop over each of its steps (can look for anything with `isinstance(..., Step)`) 

For the workflows themselves:

1. There's a new way of working with Hatchet workflows: We now have a `WorkflowConfig`, which is configuration for a workflow (name, etc.), we have a `WorkflowDeclaration`, which is generic with the type of the input to the workflow, and has methods for `run`, etc. (just `run` and `workflow_input` right now but will extend), and we have `BaseWorkflowImpl`, which is a base class intended to be inherited from in a Pydantic-y fashion, and have config passed as a class variable (similar to how Pydantic handles `model_config` by allowing you to pass a `ConfigDict`).
2. The `Hatchet` class now has an instance method `declare_workflow`, which takes workflow config keyword arguments and returns a typed `DeclarativeWorkflow` object, which you can pass to your workflow class that inherits from `BaseWorkflowImpl`. **Importantly, this behavior is opt-in. If you don't pass any config, we fall back to the old workflow behavior where you used `@workflow()` with no params**

Check out the simple and v2 examples for more of a sense of how this is intended to work. In the v2 example, the type checker is happy all the way through - it knows the type of the workflow input when it reads it from the context in the step, it knows the type of the input when we go to trigger the workflow, it infers the name of the workflow to trigger, and so on.

Important feedback I'd love:

1. **Naming** is hard - what do you think of the names of these concepts - especially the `Declaration` / `Impl` / abuse of `Workflow`?
2. Does the usage pattern here make sense? From my PoV, this isn't much overhead and gives the user a lot of power / control over their ability to use our SDK in a more type-safe manner throughout the codebase

Miscellaneous notes:

1. There's a lot of hacking around circular imports here by using `if TYPE_CHECKING` and such - don't worry about that for now. I'll do my best to fix it later.
2. There are definitely a bunch of bugs here (e.g. I stumbled upon the namespace field needing to be deleted before triggering a workflow when I went to do that - I'm sure we'll find more as I convert tests over and such).