### PR TITLE
Feat: `pydantic-settings` for managing config

### DIFF
--- a/hatchet_sdk/connection.py
+++ b/hatchet_sdk/connection.py
@@ -19,14 +19,14 @@ def new_conn(config: "ClientConfig", aio: bool) -> grpc.Channel | grpc.aio.Chann
     credentials: grpc.ChannelCredentials | None = None
 
     # load channel credentials
-    if config.tls_config.tls_strategy == "tls":
+    if config.tls_config.strategy == "tls":
         root: Any | None = None
 
         if config.tls_config.ca_file:
             root = open(config.tls_config.ca_file, "rb").read()
 
         credentials = grpc.ssl_channel_credentials(root_certificates=root)
-    elif config.tls_config.tls_strategy == "mtls":
+    elif config.tls_config.strategy == "mtls":
         assert config.tls_config.ca_file
         assert config.tls_config.key_file
         assert config.tls_config.cert_file
@@ -57,7 +57,7 @@ def new_conn(config: "ClientConfig", aio: bool) -> grpc.Channel | grpc.aio.Chann
     # When steps execute via os.fork, we see `TSI_DATA_CORRUPTED` errors.
     os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "False"
 
-    if config.tls_config.tls_strategy == "none":
+    if config.tls_config.strategy == "none":
         conn = start.insecure_channel(
             target=config.host_port,
             options=channel_options,

--- a/hatchet_sdk/connection.py
+++ b/hatchet_sdk/connection.py
@@ -22,16 +22,16 @@ def new_conn(config: "ClientConfig", aio: bool) -> grpc.Channel | grpc.aio.Chann
     if config.tls_config.strategy == "tls":
         root: Any | None = None
 
-        if config.tls_config.ca_file:
-            root = open(config.tls_config.ca_file, "rb").read()
+        if config.tls_config.root_ca_file:
+            root = open(config.tls_config.root_ca_file, "rb").read()
 
         credentials = grpc.ssl_channel_credentials(root_certificates=root)
     elif config.tls_config.strategy == "mtls":
-        assert config.tls_config.ca_file
+        assert config.tls_config.root_ca_file
         assert config.tls_config.key_file
         assert config.tls_config.cert_file
 
-        root = open(config.tls_config.ca_file, "rb").read()
+        root = open(config.tls_config.root_ca_file, "rb").read()
         private_key = open(config.tls_config.key_file, "rb").read()
         certificate_chain = open(config.tls_config.cert_file, "rb").read()
 

--- a/hatchet_sdk/loader.py
+++ b/hatchet_sdk/loader.py
@@ -9,12 +9,11 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from hatchet_sdk.token import get_addresses_from_jwt, get_tenant_id_from_jwt
 
 
-def create_settings_config(env_prefix: str, **kwargs: Any) -> SettingsConfigDict:
+def create_settings_config(env_prefix: str) -> SettingsConfigDict:
     return SettingsConfigDict(
         env_prefix=env_prefix,
         env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
         extra="ignore",
-        **kwargs,
     )
 
 
@@ -55,8 +54,7 @@ DEFAULT_HOST_PORT = "localhost:7070"
 
 class ClientConfig(BaseSettings):
     model_config = create_settings_config(
-        extra="ignore",
-        arbitrary_types_allowed=True,
+        env_prefix="HATCHET_CLIENT_",
     )
 
     token: str = ""
@@ -100,6 +98,10 @@ class ClientConfig(BaseSettings):
 
         if not self.tls_config.server_name:
             self.tls_config.server_name = self.host_port.split(":")[0]
+
+        if not self.tls_config.server_name:
+            self.tls_config.server_name = "localhost"
+
         return self
 
     @field_validator("listener_v2_timeout")

--- a/hatchet_sdk/loader.py
+++ b/hatchet_sdk/loader.py
@@ -1,5 +1,6 @@
 import json
 from logging import Logger, getLogger
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 from pydantic import Field, field_validator, model_validator
@@ -8,11 +9,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from hatchet_sdk.token import get_addresses_from_jwt, get_tenant_id_from_jwt
 
 
-class ClientTLSConfig(BaseSettings):
-    model_config = SettingsConfigDict(
-        env_prefix="HATCHET_CLIENT_TLS_",
+def create_settings_config(env_prefix: str, **kwargs: Any) -> SettingsConfigDict:
+    return SettingsConfigDict(
+        env_prefix=env_prefix,
         env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
         extra="ignore",
+        **kwargs,
+    )
+
+
+class ClientTLSConfig(BaseSettings):
+    model_config = create_settings_config(
+        env_prefix="HATCHET_CLIENT_TLS_",
     )
 
     strategy: str = "tls"
@@ -23,10 +31,8 @@ class ClientTLSConfig(BaseSettings):
 
 
 class OTELConfig(BaseSettings):
-    model_config = SettingsConfigDict(
+    model_config = create_settings_config(
         env_prefix="HATCHET_CLIENT_OTEL_",
-        env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
-        extra="ignore",
     )
 
     service_name: str | None = None
@@ -36,10 +42,8 @@ class OTELConfig(BaseSettings):
 
 
 class HealthcheckConfig(BaseSettings):
-    model_config = SettingsConfigDict(
+    model_config = create_settings_config(
         env_prefix="HATCHET_CLIENT_WORKER_HEALTHCHECK_",
-        env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
-        extra="ignore",
     )
 
     port: int = 8001
@@ -50,11 +54,9 @@ DEFAULT_HOST_PORT = "localhost:7070"
 
 
 class ClientConfig(BaseSettings):
-    model_config = SettingsConfigDict(
-        arbitrary_types_allowed=True,
+    model_config = create_settings_config(
         extra="ignore",
-        env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
-        env_prefix="HATCHET_CLIENT_",
+        arbitrary_types_allowed=True,
     )
 
     token: str = ""

--- a/hatchet_sdk/loader.py
+++ b/hatchet_sdk/loader.py
@@ -18,8 +18,8 @@ class ClientTLSConfig(BaseSettings):
     strategy: str = "tls"
     cert_file: str | None = None
     key_file: str | None = None
-    ca_file: str | None = Field(default=None, alias="root_ca_file")
-    server_name: str = "localhost"
+    root_ca_file: str | None = None
+    server_name: str = ""
 
 
 class OTELConfig(BaseSettings):
@@ -96,7 +96,8 @@ class ClientConfig(BaseSettings):
             self.host_port = grpc_broadcast_address
             self.server_url = server_url
 
-        self.tls_config.server_name = self.host_port.split(":")[0]
+        if not self.tls_config.server_name:
+            self.tls_config.server_name = self.host_port.split(":")[0]
         return self
 
     @field_validator("listener_v2_timeout")

--- a/hatchet_sdk/loader.py
+++ b/hatchet_sdk/loader.py
@@ -1,170 +1,102 @@
 import json
-import os
 from logging import Logger, getLogger
-from typing import cast
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+from pydantic import Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from hatchet_sdk.token import get_addresses_from_jwt, get_tenant_id_from_jwt
 
 
-class ClientTLSConfig(BaseModel):
-    tls_strategy: str
-    cert_file: str | None
-    key_file: str | None
-    ca_file: str | None
-    server_name: str
-
-
-def _load_tls_config(host_port: str | None = None) -> ClientTLSConfig:
-    server_name = os.getenv("HATCHET_CLIENT_TLS_SERVER_NAME")
-
-    if not server_name and host_port:
-        server_name = host_port.split(":")[0]
-
-    if not server_name:
-        server_name = "localhost"
-
-    return ClientTLSConfig(
-        tls_strategy=os.getenv("HATCHET_CLIENT_TLS_STRATEGY", "tls"),
-        cert_file=os.getenv("HATCHET_CLIENT_TLS_CERT_FILE"),
-        key_file=os.getenv("HATCHET_CLIENT_TLS_KEY_FILE"),
-        ca_file=os.getenv("HATCHET_CLIENT_TLS_ROOT_CA_FILE"),
-        server_name=server_name,
+class ClientTLSConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="HATCHET_CLIENT_TLS_",
+        env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
     )
 
-
-def parse_listener_timeout(timeout: str | None) -> int | None:
-    if timeout is None:
-        return None
-
-    return int(timeout)
+    strategy: str = "tls"
+    cert_file: str | None = None
+    key_file: str | None = None
+    ca_file: str | None = Field(default=None, alias="root_ca_file")
+    server_name: str = "localhost"
 
 
 DEFAULT_HOST_PORT = "localhost:7070"
 
 
-class ClientConfig(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True, validate_default=True)
+class ClientConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        arbitrary_types_allowed=True,
+        extra="allow",
+        env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
+        env_prefix="HATCHET_CLIENT_",
+    )
 
-    token: str = os.getenv("HATCHET_CLIENT_TOKEN", "")
+    token: str = ""
     logger: Logger = getLogger()
-    tenant_id: str = os.getenv("HATCHET_CLIENT_TENANT_ID", "")
 
-    ## IMPORTANT: Order matters here. The validators run in the order that the
-    ## fields are defined in the model. So, we need to make sure that the
-    ## host_port is set before we try to load the tls_config and server_url
-    host_port: str = os.getenv("HATCHET_CLIENT_HOST_PORT", DEFAULT_HOST_PORT)
-    tls_config: ClientTLSConfig = _load_tls_config()
-
+    tenant_id: str = ""
+    host_port: str = DEFAULT_HOST_PORT
     server_url: str = "https://app.dev.hatchet-tools.com"
-    namespace: str = os.getenv("HATCHET_CLIENT_NAMESPACE", "")
-    listener_v2_timeout: int | None = parse_listener_timeout(
-        os.getenv("HATCHET_CLIENT_LISTENER_V2_TIMEOUT")
+    namespace: str = ""
+
+    tls_config: ClientTLSConfig = Field(default_factory=lambda: ClientTLSConfig())
+
+    listener_v2_timeout: int | None = None
+    grpc_max_recv_message_length: int = Field(
+        default=4 * 1024 * 1024, description="4MB default"
     )
-    grpc_max_recv_message_length: int = int(
-        os.getenv("HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH", 4 * 1024 * 1024)
-    )  # 4MB
-    grpc_max_send_message_length: int = int(
-        os.getenv("HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH", 4 * 1024 * 1024)
-    )  # 4MB
-    otel_exporter_oltp_endpoint: str | None = os.getenv(
-        "HATCHET_CLIENT_OTEL_EXPORTER_OTLP_ENDPOINT"
+    grpc_max_send_message_length: int = Field(
+        default=4 * 1024 * 1024, description="4MB default"
     )
-    otel_service_name: str | None = os.getenv("HATCHET_CLIENT_OTEL_SERVICE_NAME")
-    otel_exporter_oltp_headers: str | None = os.getenv(
-        "HATCHET_CLIENT_OTEL_EXPORTER_OTLP_HEADERS"
-    )
-    otel_exporter_oltp_protocol: str | None = os.getenv(
-        "HATCHET_CLIENT_OTEL_EXPORTER_OTLP_PROTOCOL"
-    )
-    worker_healthcheck_port: int = int(
-        os.getenv("HATCHET_CLIENT_WORKER_HEALTHCHECK_PORT", 8001)
-    )
-    worker_healthcheck_enabled: bool = (
-        os.getenv("HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED", "False") == "True"
-    )
+    otel_exporter_oltp_endpoint: str | None = None
+    otel_service_name: str | None = None
+    otel_exporter_oltp_headers: str | None = None
+    otel_exporter_oltp_protocol: str | None = None
+    worker_healthcheck_port: int = 8001
+    worker_healthcheck_enabled: bool = False
 
     worker_preset_labels: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("token", mode="after")
-    @classmethod
-    def validate_token(cls, token: str) -> str:
-        if not token:
+    @model_validator(mode="after")
+    def validate_token_and_tenant(self) -> "ClientConfig":
+        if not self.token:
             raise ValueError("Token must be set")
 
-        return token
+        if not self.tenant_id:
+            self.tenant_id = get_tenant_id_from_jwt(self.token)
 
-    @field_validator("namespace", mode="after")
+        return self
+
+    @model_validator(mode="after")
+    def validate_addresses(self) -> "ClientConfig":
+        if self.host_port == DEFAULT_HOST_PORT:
+            server_url, grpc_broadcast_address = get_addresses_from_jwt(self.token)
+            self.host_port = grpc_broadcast_address
+            self.server_url = server_url
+
+        self.tls_config.server_name = self.host_port.split(":")[0]
+        return self
+
+    @field_validator("listener_v2_timeout")
+    @classmethod
+    def validate_listener_timeout(cls, value: int | None | str) -> int | None:
+        if value is None:
+            return None
+
+        if isinstance(value, int):
+            return value
+
+        return int(value)
+
+    @field_validator("namespace")
     @classmethod
     def validate_namespace(cls, namespace: str) -> str:
         if not namespace:
             return ""
-
         if not namespace.endswith("_"):
             namespace = f"{namespace}_"
-
         return namespace.lower()
-
-    @field_validator("tenant_id", mode="after")
-    @classmethod
-    def validate_tenant_id(cls, tenant_id: str, info: ValidationInfo) -> str:
-        token = cast(str | None, info.data.get("token"))
-
-        if not tenant_id:
-            if not token:
-                raise ValueError("Either the token or tenant_id must be set")
-
-            return get_tenant_id_from_jwt(token)
-
-        return tenant_id
-
-    @field_validator("host_port", mode="after")
-    @classmethod
-    def validate_host_port(cls, host_port: str, info: ValidationInfo) -> str:
-        if host_port and host_port != DEFAULT_HOST_PORT:
-            return host_port
-
-        token = cast(str, info.data.get("token"))
-
-        if not token:
-            raise ValueError("Token must be set")
-
-        _, grpc_broadcast_address = get_addresses_from_jwt(token)
-
-        return grpc_broadcast_address
-
-    @field_validator("server_url", mode="after")
-    @classmethod
-    def validate_server_url(cls, server_url: str, info: ValidationInfo) -> str:
-        ## IMPORTANT: Order matters here. The validators run in the order that the
-        ## fields are defined in the model. So, we need to make sure that the
-        ## host_port is set before we try to load the server_url
-        host_port = cast(str, info.data.get("host_port"))
-
-        if host_port and host_port != DEFAULT_HOST_PORT:
-            return host_port
-
-        token = cast(str, info.data.get("token"))
-
-        if not token:
-            raise ValueError("Token must be set")
-
-        _server_url, _ = get_addresses_from_jwt(token)
-
-        return _server_url
-
-    @field_validator("tls_config", mode="after")
-    @classmethod
-    def validate_tls_config(
-        cls, tls_config: ClientTLSConfig, info: ValidationInfo
-    ) -> ClientTLSConfig:
-        ## IMPORTANT: Order matters here. This validator runs in the order
-        ## that the fields are defined in the model. So, we need to make sure
-        ## that the host_port is set before we try to load the tls_config
-        host_port = cast(str, info.data.get("host_port"))
-
-        return _load_tls_config(host_port)
 
     def __hash__(self) -> int:
         return hash(json.dumps(self.model_dump(), default=str))

--- a/hatchet_sdk/loader.py
+++ b/hatchet_sdk/loader.py
@@ -12,6 +12,7 @@ class ClientTLSConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="HATCHET_CLIENT_TLS_",
         env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
+        extra="ignore",
     )
 
     strategy: str = "tls"
@@ -21,13 +22,37 @@ class ClientTLSConfig(BaseSettings):
     server_name: str = "localhost"
 
 
+class OTELConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="HATCHET_CLIENT_OTEL_",
+        env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
+        extra="ignore",
+    )
+
+    service_name: str | None = None
+    exporter_otlp_endpoint: str | None = None
+    exporter_otlp_headers: str | None = None
+    exporter_otlp_protocol: str | None = None
+
+
+class HealthcheckConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="HATCHET_CLIENT_WORKER_HEALTHCHECK_",
+        env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
+        extra="ignore",
+    )
+
+    port: int = 8001
+    enabled: bool = False
+
+
 DEFAULT_HOST_PORT = "localhost:7070"
 
 
 class ClientConfig(BaseSettings):
     model_config = SettingsConfigDict(
         arbitrary_types_allowed=True,
-        extra="allow",
+        extra="ignore",
         env_file=(".env", ".env.hatchet", ".env.dev", ".env.local"),
         env_prefix="HATCHET_CLIENT_",
     )
@@ -41,6 +66,8 @@ class ClientConfig(BaseSettings):
     namespace: str = ""
 
     tls_config: ClientTLSConfig = Field(default_factory=lambda: ClientTLSConfig())
+    otel: OTELConfig = Field(default_factory=lambda: OTELConfig())
+    healthcheck: HealthcheckConfig = Field(default_factory=lambda: HealthcheckConfig())
 
     listener_v2_timeout: int | None = None
     grpc_max_recv_message_length: int = Field(
@@ -49,12 +76,6 @@ class ClientConfig(BaseSettings):
     grpc_max_send_message_length: int = Field(
         default=4 * 1024 * 1024, description="4MB default"
     )
-    otel_exporter_oltp_endpoint: str | None = None
-    otel_service_name: str | None = None
-    otel_exporter_oltp_headers: str | None = None
-    otel_exporter_oltp_protocol: str | None = None
-    worker_healthcheck_port: int = 8001
-    worker_healthcheck_enabled: bool = False
 
     worker_preset_labels: dict[str, str] = Field(default_factory=dict)
 

--- a/hatchet_sdk/utils/tracing.py
+++ b/hatchet_sdk/utils/tracing.py
@@ -30,14 +30,14 @@ def parse_headers(headers: str | None) -> dict[str, str]:
 def create_tracer(config: ClientConfig) -> Tracer:
     ## TODO: Figure out how to specify protocol here
     resource = Resource(
-        attributes={SERVICE_NAME: config.otel_service_name or "hatchet.run"}
+        attributes={SERVICE_NAME: config.otel.service_name or "hatchet.run"}
     )
 
-    if config.otel_exporter_oltp_endpoint and config.otel_exporter_oltp_headers:
+    if config.otel.exporter_otlp_endpoint and config.otel.exporter_otlp_headers:
         processor = BatchSpanProcessor(
             OTLPSpanExporter(
-                endpoint=config.otel_exporter_oltp_endpoint,
-                headers=parse_headers(config.otel_exporter_oltp_headers),
+                endpoint=config.otel.exporter_otlp_endpoint,
+                headers=parse_headers(config.otel.exporter_otlp_headers),
             ),
         )
 

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -178,7 +178,7 @@ class Worker:
         return web.Response(body=generate_latest(), content_type="text/plain")
 
     async def start_health_server(self) -> None:
-        port = self.config.worker_healthcheck_port or 8001
+        port = self.config.healthcheck.port
 
         app = web.Application()
         app.add_routes(
@@ -237,7 +237,7 @@ class Worker:
         if not _from_start:
             self.setup_loop(options.loop)
 
-        if self.config.worker_healthcheck_enabled:
+        if self.config.healthcheck.enabled:
             await self.start_health_server()
 
         self.action_listener_process = self._start_listener()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1562,6 +1562,27 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.7.1"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.7.1-py3-none-any.whl", hash = "sha256:590be9e6e24d06db33a4262829edef682500ef008565a969c73d39d5f8bfb3fd"},
+    {file = "pydantic_settings-2.7.1.tar.gz", hash = "sha256:10c9caad35e64bfb3c2fbf70a078c0e25cc92499782e5200747f942a065dec93"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
@@ -2109,4 +2130,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "e59b746d16c418856dbf00015dfb396a703e13961b53e0196bb511c530920e47"
+content-hash = "9ca2d219cdeffdf5e53d2b7e2b0ff3263eace96e98f992c9a10ab2a7baf737c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ opentelemetry-distro = ">=0.49b0"
 opentelemetry-exporter-otlp = "^1.28.0"
 opentelemetry-exporter-otlp-proto-http = "^1.28.0"
 prometheus-client = "^0.21.1"
+pydantic-settings = "^2.7.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"


### PR DESCRIPTION
Finally got around to updating the `ClientConfig` to use `pydantic-settings` 😅 

Now, the config will basically first try to read from env vars, then it'll try to read from a `.env`, `.env.hatchet`, `.env.local`, and `.env.dev` (in that order). This should prevent us from needing `load_dotenv` everywhere, and will also continue the current behavior of working in production for users who are loading config from environment variables.

This also gets rid of race conditions between imports and `load_dotenv` being called in the examples (or in downstream code)