### PR TITLE
Feat: Rework Admin Client

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -84,12 +84,12 @@ def worker(
 
     time.sleep(5)
 
-    def log_output(pipe: BytesIO) -> None:
+    def log_output(pipe: BytesIO, log_func: Callable[[str], None]) -> None:
         for line in iter(pipe.readline, b""):
-            print(line.decode().strip())
+            log_func(line.decode().strip())
 
-    Thread(target=log_output, args=(proc.stdout, ), daemon=True).start()
-    Thread(target=log_output, args=(proc.stderr,), daemon=True).start()
+    Thread(target=log_output, args=(proc.stdout, logging.info), daemon=True).start()
+    Thread(target=log_output, args=(proc.stderr, logging.error), daemon=True).start()
 
     yield proc
 

--- a/conftest.py
+++ b/conftest.py
@@ -84,12 +84,12 @@ def worker(
 
     time.sleep(5)
 
-    def log_output(pipe: BytesIO, log_func: Callable[[str], None]) -> None:
+    def log_output(pipe: BytesIO) -> None:
         for line in iter(pipe.readline, b""):
-            log_func(line.decode().strip())
+            print(line.decode().strip())
 
-    Thread(target=log_output, args=(proc.stdout, logging.info), daemon=True).start()
-    Thread(target=log_output, args=(proc.stderr, logging.error), daemon=True).start()
+    Thread(target=log_output, args=(proc.stdout, ), daemon=True).start()
+    Thread(target=log_output, args=(proc.stderr,), daemon=True).start()
 
     yield proc
 

--- a/examples/bulk_fanout/test_bulk_fanout.py
+++ b/examples/bulk_fanout/test_bulk_fanout.py
@@ -9,13 +9,5 @@ from hatchet_sdk import Hatchet, Worker
 async def test_run(hatchet: Hatchet, worker: Worker) -> None:
     run = hatchet.admin.run_workflow("BulkParent", {"n": 12})
     result = await run.result()
+
     assert len(result["spawn"]["results"]) == 12
-
-
-# requires scope module or higher for shared event loop
-@pytest.mark.asyncio(scope="session")
-@pytest.mark.parametrize("worker", ["bulk_fanout"], indirect=True)
-async def test_run2(hatchet: Hatchet, worker: Worker) -> None:
-    run = hatchet.admin.run_workflow("BulkParent", {"n": 10})
-    result = await run.result()
-    assert len(result["spawn"]["results"]) == 10

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -24,6 +24,8 @@ from hatchet_sdk.contracts.workflows_pb2 import (
     WorkflowVersion,
 )
 from hatchet_sdk.contracts.workflows_pb2_grpc import WorkflowServiceStub
+from hatchet_sdk.loader import ClientConfig
+from hatchet_sdk.metadata import get_metadata
 from hatchet_sdk.utils.serialization import flatten
 from hatchet_sdk.utils.tracing import (
     create_carrier,
@@ -33,9 +35,6 @@ from hatchet_sdk.utils.tracing import (
 )
 from hatchet_sdk.utils.types import JSONSerializableDict
 from hatchet_sdk.workflow_run import WorkflowRunRef
-
-from ..loader import ClientConfig
-from ..metadata import get_metadata
 
 
 def new_admin(config: ClientConfig) -> "AdminClient":

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from datetime import datetime
-from typing import Any, TypeVar, Union, cast
+from typing import Any, Union, cast
 
 import grpc
 from google.protobuf import timestamp_pb2
@@ -78,9 +78,6 @@ class DedupeViolationErr(Exception):
     """Raised by the Hatchet library to indicate that a workflow has already been run with this deduplication value."""
 
     pass
-
-
-T = TypeVar("T")
 
 
 class AdminClient:

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -1,6 +1,7 @@
+import asyncio
 import json
 from datetime import datetime
-from typing import Any, Callable, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 import grpc
 from google.protobuf import timestamp_pb2
@@ -31,7 +32,7 @@ from hatchet_sdk.utils.tracing import (
     parse_carrier_from_metadata,
 )
 from hatchet_sdk.utils.types import JSONSerializableDict
-from hatchet_sdk.workflow_run import RunRef, WorkflowRunRef
+from hatchet_sdk.workflow_run import WorkflowRunRef
 
 from ..loader import ClientConfig
 from ..metadata import get_metadata
@@ -79,8 +80,20 @@ class DedupeViolationErr(Exception):
     pass
 
 
-class AdminClientBase:
+T = TypeVar("T")
+
+
+class AdminClient:
     pooled_workflow_listener: PooledWorkflowRunListener | None = None
+
+    def __init__(self, config: ClientConfig):
+        conn = new_conn(config, False)
+        self.config = config
+        self.client = WorkflowServiceStub(conn)  # type: ignore[no-untyped-call]
+        self.token = config.token
+        self.listener_client = new_listener(config)
+        self.namespace = config.namespace
+        self.otel_tracer = create_tracer(config=config)
 
     def _prepare_workflow_request(
         self, workflow_name: str, input: dict[str, Any], options: TriggerWorkflowOptions
@@ -161,218 +174,52 @@ class AdminClientBase:
             **options.model_dump(),
         )
 
-
-T = TypeVar("T")
-
-
-class AdminClientAioImpl(AdminClientBase):
-    def __init__(self, config: ClientConfig):
-        aio_conn = new_conn(config, True)
-        self.config = config
-        self.aio_client = WorkflowServiceStub(aio_conn)  # type: ignore[no-untyped-call]
-        self.token = config.token
-        self.listener_client = new_listener(config)
-        self.namespace = config.namespace
-        self.otel_tracer = create_tracer(config=config)
-
-    async def run(
-        self,
-        function: Union[str, Callable[[Any], T]],
-        input: JSONSerializableDict,
-        options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
-    ) -> "RunRef[T]":
-        workflow_name = cast(
-            str,
-            (
-                function
-                if isinstance(function, str)
-                else getattr(function, "function_name")
-            ),
-        )
-
-        wrr = await self.run_workflow(workflow_name, input, options)
-
-        return RunRef[T](
-            wrr.workflow_run_id, wrr.workflow_listener, wrr.workflow_run_event_listener
-        )
-
     @tenacity_retry
-    async def run_workflow(
+    async def arun_workflow(
         self,
         workflow_name: str,
         input: JSONSerializableDict,
         options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
     ) -> WorkflowRunRef:
-        ctx = parse_carrier_from_metadata(options.additional_metadata)
-
-        with self.otel_tracer.start_as_current_span(
-            f"hatchet.async_run_workflow.{workflow_name}", context=ctx
-        ) as span:
-            carrier = create_carrier()
-
-            try:
-                if not self.pooled_workflow_listener:
-                    self.pooled_workflow_listener = PooledWorkflowRunListener(
-                        self.config
-                    )
-
-                namespace = options.namespace or self.namespace
-
-                if namespace != "" and not workflow_name.startswith(self.namespace):
-                    workflow_name = f"{namespace}{workflow_name}"
-
-                options.additional_metadata = inject_carrier_into_metadata(
-                    options.additional_metadata, carrier
-                )
-
-                span.set_attributes(
-                    flatten(options.additional_metadata, parent_key="", separator=".")
-                )
-
-                request = self._prepare_workflow_request(workflow_name, input, options)
-
-                span.add_event(
-                    "Triggering workflow", attributes={"workflow_name": workflow_name}
-                )
-
-                resp: TriggerWorkflowResponse = await self.aio_client.TriggerWorkflow(
-                    request,
-                    metadata=get_metadata(self.token),
-                )
-
-                span.add_event(
-                    "Received workflow response",
-                    attributes={"workflow_name": workflow_name},
-                )
-
-                return WorkflowRunRef(
-                    workflow_run_id=resp.workflow_run_id,
-                    workflow_listener=self.pooled_workflow_listener,
-                    workflow_run_event_listener=self.listener_client,
-                )
-            except (grpc.RpcError, grpc.aio.AioRpcError) as e:
-                if e.code() == grpc.StatusCode.ALREADY_EXISTS:
-                    raise DedupeViolationErr(e.details())
-
-                raise e
+        return await asyncio.to_thread(self.run_workflow, workflow_name, input, options)
 
     @tenacity_retry
-    async def run_workflows(
+    async def arun_workflows(
         self,
         workflows: list[WorkflowRunDict],
         options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
     ) -> list[WorkflowRunRef]:
-        if len(workflows) == 0:
-            raise ValueError("No workflows to run")
-
-        if not self.pooled_workflow_listener:
-            self.pooled_workflow_listener = PooledWorkflowRunListener(self.config)
-
-        namespace = options.namespace or self.namespace
-
-        workflow_run_requests: list[TriggerWorkflowRequest] = []
-
-        for workflow in workflows:
-            workflow_name = workflow.workflow_name
-            input_data = workflow.input
-            options = workflow.options
-
-            if namespace != "" and not workflow_name.startswith(self.namespace):
-                workflow_name = f"{namespace}{workflow_name}"
-
-            # Prepare and trigger workflow for each workflow name and input
-            request = self._prepare_workflow_request(workflow_name, input_data, options)
-            workflow_run_requests.append(request)
-
-        resp: BulkTriggerWorkflowResponse = await self.aio_client.BulkTriggerWorkflow(
-            BulkTriggerWorkflowRequest(workflows=workflow_run_requests),
-            metadata=get_metadata(self.token),
-        )
-
-        return [
-            WorkflowRunRef(
-                workflow_run_id=workflow_run_id,
-                workflow_listener=self.pooled_workflow_listener,
-                workflow_run_event_listener=self.listener_client,
-            )
-            for workflow_run_id in resp.workflow_run_ids
-        ]
+        return await asyncio.to_thread(self.run_workflows, workflows, options)
 
     @tenacity_retry
-    async def put_workflow(
+    async def aput_workflow(
         self,
         name: str,
         workflow: CreateWorkflowVersionOpts,
         overrides: CreateWorkflowVersionOpts | None = None,
     ) -> WorkflowVersion:
-        opts = self._prepare_put_workflow_request(name, workflow, overrides)
-
-        return cast(
-            WorkflowVersion,
-            await self.aio_client.PutWorkflow(
-                opts,
-                metadata=get_metadata(self.token),
-            ),
-        )
+        return await asyncio.to_thread(self.put_workflow, name, workflow, overrides)
 
     @tenacity_retry
-    async def put_rate_limit(
+    async def aput_rate_limit(
         self,
         key: str,
         limit: int,
         duration: RateLimitDuration = RateLimitDuration.SECOND,
     ) -> None:
-        await self.aio_client.PutRateLimit(
-            PutRateLimitRequest(
-                key=key,
-                limit=limit,
-                duration=duration,
-            ),
-            metadata=get_metadata(self.token),
-        )
+        return await asyncio.to_thread(self.put_rate_limit, key, limit, duration)
 
     @tenacity_retry
-    async def schedule_workflow(
+    async def aschedule_workflow(
         self,
         name: str,
         schedules: list[Union[datetime, timestamp_pb2.Timestamp]],
         input: JSONSerializableDict = {},
         options: ScheduleTriggerWorkflowOptions = ScheduleTriggerWorkflowOptions(),
     ) -> WorkflowVersion:
-        try:
-            namespace = options.namespace or self.namespace
-
-            if namespace != "" and not name.startswith(self.namespace):
-                name = f"{namespace}{name}"
-
-            request = self._prepare_schedule_workflow_request(
-                name, schedules, input, options
-            )
-
-            return cast(
-                WorkflowVersion,
-                await self.aio_client.ScheduleWorkflow(
-                    request,
-                    metadata=get_metadata(self.token),
-                ),
-            )
-        except (grpc.aio.AioRpcError, grpc.RpcError) as e:
-            if e.code() == grpc.StatusCode.ALREADY_EXISTS:
-                raise DedupeViolationErr(e.details())
-
-            raise e
-
-
-class AdminClient(AdminClientBase):
-    def __init__(self, config: ClientConfig):
-        conn = new_conn(config, False)
-        self.config = config
-        self.client = WorkflowServiceStub(conn)  # type: ignore[no-untyped-call]
-        self.aio = AdminClientAioImpl(config)
-        self.token = config.token
-        self.listener_client = new_listener(config)
-        self.namespace = config.namespace
-        self.otel_tracer = create_tracer(config=config)
+        return await asyncio.to_thread(
+            self.schedule_workflow, name, schedules, input, options
+        )
 
     @tenacity_retry
     def put_workflow(
@@ -539,27 +386,6 @@ class AdminClient(AdminClientBase):
             )
             for workflow_run_id in resp.workflow_run_ids
         ]
-
-    def run(
-        self,
-        function: Union[str, Callable[[Any], T]],
-        input: JSONSerializableDict,
-        options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
-    ) -> "RunRef[T]":
-        workflow_name = cast(
-            str,
-            (
-                function
-                if isinstance(function, str)
-                else getattr(function, "function_name")
-            ),
-        )
-
-        wrr = self.run_workflow(workflow_name, input, options)
-
-        return RunRef[T](
-            wrr.workflow_run_id, wrr.workflow_listener, wrr.workflow_run_event_listener
-        )
 
     def get_workflow_run(self, workflow_run_id: str) -> WorkflowRunRef:
         try:

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -181,6 +181,12 @@ class AdminClient:
         input: JSONSerializableDict,
         options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
     ) -> WorkflowRunRef:
+        ## IMPORTANT: The `pooled_workflow_listener` must be created 1) lazily, and not at `init` time, and 2) on the
+        ## main thread. If 1) is not followed, you'll get an error about something being attached to the wrong event
+        ## loop. If 2) is not followed, you'll get an error about the event loop not being set up.
+        if not self.pooled_workflow_listener:
+            self.pooled_workflow_listener = PooledWorkflowRunListener(self.config)
+
         return await asyncio.to_thread(self.run_workflow, workflow_name, input, options)
 
     @tenacity_retry
@@ -189,6 +195,12 @@ class AdminClient:
         workflows: list[WorkflowRunDict],
         options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
     ) -> list[WorkflowRunRef]:
+        ## IMPORTANT: The `pooled_workflow_listener` must be created 1) lazily, and not at `init` time, and 2) on the
+        ## main thread. If 1) is not followed, you'll get an error about something being attached to the wrong event
+        ## loop. If 2) is not followed, you'll get an error about the event loop not being set up.
+        if not self.pooled_workflow_listener:
+            self.pooled_workflow_listener = PooledWorkflowRunListener(self.config)
+
         return await asyncio.to_thread(self.run_workflows, workflows, options)
 
     @tenacity_retry
@@ -198,6 +210,12 @@ class AdminClient:
         workflow: CreateWorkflowVersionOpts,
         overrides: CreateWorkflowVersionOpts | None = None,
     ) -> WorkflowVersion:
+        ## IMPORTANT: The `pooled_workflow_listener` must be created 1) lazily, and not at `init` time, and 2) on the
+        ## main thread. If 1) is not followed, you'll get an error about something being attached to the wrong event
+        ## loop. If 2) is not followed, you'll get an error about the event loop not being set up.
+        if not self.pooled_workflow_listener:
+            self.pooled_workflow_listener = PooledWorkflowRunListener(self.config)
+
         return await asyncio.to_thread(self.put_workflow, name, workflow, overrides)
 
     @tenacity_retry
@@ -207,6 +225,12 @@ class AdminClient:
         limit: int,
         duration: RateLimitDuration = RateLimitDuration.SECOND,
     ) -> None:
+        ## IMPORTANT: The `pooled_workflow_listener` must be created 1) lazily, and not at `init` time, and 2) on the
+        ## main thread. If 1) is not followed, you'll get an error about something being attached to the wrong event
+        ## loop. If 2) is not followed, you'll get an error about the event loop not being set up.
+        if not self.pooled_workflow_listener:
+            self.pooled_workflow_listener = PooledWorkflowRunListener(self.config)
+
         return await asyncio.to_thread(self.put_rate_limit, key, limit, duration)
 
     @tenacity_retry
@@ -217,6 +241,12 @@ class AdminClient:
         input: JSONSerializableDict = {},
         options: ScheduleTriggerWorkflowOptions = ScheduleTriggerWorkflowOptions(),
     ) -> WorkflowVersion:
+        ## IMPORTANT: The `pooled_workflow_listener` must be created 1) lazily, and not at `init` time, and 2) on the
+        ## main thread. If 1) is not followed, you'll get an error about something being attached to the wrong event
+        ## loop. If 2) is not followed, you'll get an error about the event loop not being set up.
+        if not self.pooled_workflow_listener:
+            self.pooled_workflow_listener = PooledWorkflowRunListener(self.config)
+
         return await asyncio.to_thread(
             self.schedule_workflow, name, schedules, input, options
         )

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -383,6 +383,7 @@ class AdminClient:
         options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
     ) -> list[WorkflowRunRef]:
         workflow_run_requests: list[TriggerWorkflowRequest] = []
+
         if not self.pooled_workflow_listener:
             self.pooled_workflow_listener = PooledWorkflowRunListener(self.config)
 
@@ -393,13 +394,13 @@ class AdminClient:
 
             namespace = options.namespace or self.namespace
 
-        if namespace != "" and not workflow_name.startswith(self.namespace):
-            workflow_name = f"{namespace}{workflow_name}"
+            if namespace != "" and not workflow_name.startswith(self.namespace):
+                workflow_name = f"{namespace}{workflow_name}"
 
-        # Prepare and trigger workflow for each workflow name and input
-        request = self._prepare_workflow_request(workflow_name, input_data, options)
+            # Prepare and trigger workflow for each workflow name and input
+            request = self._prepare_workflow_request(workflow_name, input_data, options)
 
-        workflow_run_requests.append(request)
+            workflow_run_requests.append(request)
 
         bulk_request = BulkTriggerWorkflowRequest(workflows=workflow_run_requests)
 

--- a/hatchet_sdk/context/context.py
+++ b/hatchet_sdk/context/context.py
@@ -312,7 +312,7 @@ class Context:
 
         trigger_options = self._prepare_workflow_options(key, options, worker_id)
 
-        return await self.admin_client.aio.run_workflow(
+        return await self.admin_client.arun_workflow(
             workflow_name, input, trigger_options
         )
 
@@ -337,4 +337,4 @@ class Context:
             for child_workflow_run in child_workflow_runs
         ]
 
-        return await self.admin_client.aio.run_workflows(bulk_trigger_workflow_runs)
+        return await self.admin_client.arun_workflows(bulk_trigger_workflow_runs)

--- a/hatchet_sdk/workflow.py
+++ b/hatchet_sdk/workflow.py
@@ -283,7 +283,7 @@ class WorkflowDeclaration(Generic[TWorkflowInput]):
         if not self.hatchet:
             raise ValueError("Hatchet client is not initialized.")
 
-        return await self.hatchet.admin.aio.schedule_workflow(
+        return await self.hatchet.admin.aschedule_workflow(
             name=self.config.name,
             schedules=schedules,
             input=input.model_dump(),


### PR DESCRIPTION
The aio_client on the AdminClient seems to just have a bunch of duped code that replaces the original gRPC client with the async one, which also causes problems when using asyncio.run (or other cases with existing event loops, like in Pytest). Proposal here is to replace it with a call to asyncio.to_thread on the sync methods like we do in the event client.